### PR TITLE
v1.4.22 — G-code preview upgrade, loading text, file picker, travel toggle

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -20,6 +20,10 @@ Open bugs, features, and investigations. Everything else is done — see git log
 - Native fix: overflow guards in `IntersectPoint` (vertical-edge + general-case `Dx*q+b`) and `Round()` (large double detection), all falling back to scanbeam position
 - v1.4.21: clear stale clipper markers on APK upgrade to prevent false crash report after updating
 
+### B36: MakerWorld download/loading text is unclear — FIXED v1.4.22
+- Status messages during MakerWorld import were confusing (e.g. "Loading Downloading from MakerWorld……")
+- Fixed: each loading state now provides a complete display message ("Downloading from MakerWorld…", "Loading model.3mf…", "Preparing model…")
+
 ## Open Features
 
 ### F14: Mixed-colour / pseudo-extruder support (FullSpectrum fork)
@@ -31,6 +35,10 @@ Open bugs, features, and investigations. Everything else is done — see git log
 
 ## Closed (recent)
 See git log for full history. Most recent fixes:
+- **B36**: MakerWorld download/loading text was confusing ("Loading Downloading from MakerWorld……") — each state now provides complete display message — FIXED v1.4.22
+- **F37**: File picker showed all file types — removed `*/*` wildcard, now filters to 3MF/STL/OBJ only — DONE v1.4.22
+- **F38**: G-code preview upgraded to box-tube geometry (top + left + right faces) with bottom-to-top brightness gradient matching u1-slicer-bridge quality — DONE v1.4.22
+- **F39**: Travel move toggle added to inline G-code preview on Preview screen, brighter travel line color — DONE v1.4.22
 - **B31/F35**: Clipper coordinate overflow crash on multi-colour SEMM models — native overflow guards in `IntersectPoint` and `Round()`, Kotlin wipe tower clamping, crash-loop prevention, stale marker cleanup on APK upgrade — FIXED v1.4.20/v1.4.21
 - **Cookie file import**: CookieInfoDialog with browser export + file transfer instructions, stream handling fixes — DONE v1.4.20
 - **F36 (bed temp)**: Editable bed temp field below plate type selector — DONE v1.4.19

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,13 +49,13 @@ Public vulnerability reports should follow [`SECURITY.md`](SECURITY.md). Keep an
 ## Test
 
 ```bash
-./gradlew testDebugUnitTest                        # 468 JVM unit tests
+./gradlew testDebugUnitTest                        # 482 JVM unit tests
 ./gradlew connectedDebugAndroidTest                # 118 instrumented tests (uses Orchestrator)
 ```
 
 For local device IDs and any private E2E notes, consult `E2E_TESTING.local.md` if present.
 
-### Unit tests (`app/src/test/`) - 468 tests across 29 classes
+### Unit tests (`app/src/test/`) - 482 tests across 30 classes
 - `gcode/GcodeParserTest.kt` (26) — G-code parsing: layers, extrusion, extruder switching, ;TYPE: feature-type tagging, wipeTowerFilamentMm
 - `gcode/GcodeValidatorTest.kt` (41) — Tool changes, nozzle temps, layer count, prime tower footprint, bed bounds validation
 - `gcode/GcodeToolRemapperTest.kt` (19) — Compact tool index remapping, SM_ params, M104/M109
@@ -75,6 +75,7 @@ For local device IDs and any private E2E notes, consult `E2E_TESTING.local.md` i
 - `ui/ExtruderAssignmentTest.kt` (6) — ExtruderAssignment defaults, copy, list building
 - `ui/FilamentJsonImportTest.kt` (15) — JSON import parsing: snake_case/camelCase, defaults, errors
 - `ui/MultiColorMappingTest.kt` (9) — ensureMultiSlotMapping collapse detection and sequential distribution
+- `ui/PrinterStatusBadgeTest.kt` (14) — Printer status badge text, color, and icon mapping for all printer states
 - `model/CopyArrangeCalculatorTest.kt` (18) — Centered grid layout, bed bounds, copy capping, wipe tower auto-positioning, skirt clearance
 - `UpgradeDetectorTest.kt` (15) — APK upgrade detection logic, version/timestamp comparison, file clearing patterns
 - `DiagnosticsStoreTest.kt` (5) — Diagnostics event logging, JSONL output

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The native `.so` is pre-built and committed to `app/src/main/jniLibs/arm64-v8a/`
 ## Testing
 
 ```bash
-./gradlew testDebugUnitTest              # 468 JVM unit tests
+./gradlew testDebugUnitTest              # 482 JVM unit tests
 ./gradlew connectedDebugAndroidTest      # 118 instrumented tests (ARM64 device required)
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "com.u1.slicer.orca"
         minSdk 26
         targetSdk 34
-        versionCode 110
-        versionName "1.4.21"
+        versionCode 111
+        versionName "1.4.22"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/u1/slicer/MainActivity.kt
+++ b/app/src/main/java/com/u1/slicer/MainActivity.kt
@@ -302,7 +302,7 @@ class MainActivity : ComponentActivity() {
                 }
                 val appSlicerState by viewModel.state.collectAsState()
                 val sharedPreviewModelKey = when (val s = appSlicerState) {
-                    is SlicerViewModel.SlicerState.Loading -> "loading:${s.filename}"
+                    is SlicerViewModel.SlicerState.Loading -> "loading:${s.message}"
                     else -> viewModel.previewModelPath ?: viewModel.currentModelPath
                 }
                 LaunchedEffect(sharedPreviewModelKey) {
@@ -332,8 +332,7 @@ class MainActivity : ComponentActivity() {
                     "application/octet-stream",
                     "model/3mf",
                     "application/vnd.ms-3mfdocument",
-                    "model/obj",
-                    "*/*"
+                    "model/obj"
                 )
 
                 U1NavGraph(
@@ -645,7 +644,7 @@ fun PrepareScreen(
                                 verticalArrangement = Arrangement.spacedBy(12.dp)
                             ) {
                                 CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
-                                Text("Loading ${s.filename}…",
+                                Text(s.message,
                                     style = MaterialTheme.typography.bodyMedium,
                                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f))
                             }
@@ -2457,6 +2456,7 @@ fun InlineGcodePreview(
 ) {
     var viewerView by remember { mutableStateOf<com.u1.slicer.viewer.GcodeViewerView?>(null) }
     var viewerLoading by remember(parsedGcode) { mutableStateOf(true) }
+    var showTravel by remember { mutableStateOf(false) }
     val gcodeLayerCount = parsedGcode.layers.size
     // Use slicer's totalLayers for display (correct print layers), fall back to parsed count
     val displayLayerCount = if (slicerLayerCount > 0) slicerLayerCount else gcodeLayerCount
@@ -2513,12 +2513,24 @@ fun InlineGcodePreview(
                     },
                     modifier = Modifier.fillMaxSize()
                 )
-                IconButton(
-                    onClick = onExpand,
-                    modifier = Modifier.align(Alignment.TopEnd).padding(4.dp)
+                Row(
+                    modifier = Modifier.align(Alignment.BottomEnd).padding(4.dp)
                 ) {
-                    Icon(Icons.Default.Fullscreen, "Full screen",
-                        tint = Color.White.copy(alpha = 0.8f))
+                    IconButton(onClick = {
+                        showTravel = !showTravel
+                        viewerView?.setShowTravel(showTravel)
+                    }) {
+                        Icon(
+                            if (showTravel) Icons.Default.Visibility else Icons.Default.VisibilityOff,
+                            "Toggle travel moves",
+                            tint = if (showTravel) Color.White
+                                   else Color.White.copy(alpha = 0.4f)
+                        )
+                    }
+                    IconButton(onClick = onExpand) {
+                        Icon(Icons.Default.Fullscreen, "Full screen",
+                            tint = Color.White.copy(alpha = 0.8f))
+                    }
                 }
                 // Layer label overlay — map gcode layer index to display layer
                 Text(

--- a/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
@@ -57,7 +57,7 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
     // ---- UI State ----
     sealed class SlicerState {
         object Idle : SlicerState()
-        data class Loading(val filename: String) : SlicerState()
+        data class Loading(val message: String) : SlicerState()
         data class ModelLoaded(val info: ModelInfo) : SlicerState()
         data class Slicing(val progress: Int, val stage: String) : SlicerState()
         data class SliceComplete(val result: SliceResult) : SlicerState()
@@ -382,7 +382,7 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
                     val fileName = parsed.fileName
                     Log.i("SlicerVM", "MakerWorld redirect: $fileName -> ${fileUrl.take(80)}...")
                     currentModelName = fileName
-                    _state.value = SlicerState.Loading(fileName)
+                    _state.value = SlicerState.Loading("Downloading $fileName…")
 
                     val fileRequest = okhttp3.Request.Builder().url(fileUrl)
                         .header("User-Agent", "U1Slicer/1.0 Android").get().build()
@@ -490,7 +490,7 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
 
                 val filename = getDisplayName(context, uri) ?: "model.stl"
                 currentModelName = filename
-                _state.value = SlicerState.Loading(filename)
+                _state.value = SlicerState.Loading("Loading $filename…")
                 val file = File(context.filesDir, filename)
                 // Copy via temp file to avoid self-referential truncation
                 // when the source URI points to our own FileProvider
@@ -614,7 +614,7 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
 
                 val filename = file.name
                 currentModelName = filename
-                _state.value = SlicerState.Loading(filename)
+                _state.value = SlicerState.Loading("Loading $filename…")
 
                 rawInputFile = file
                 recoveryPlateId = -1

--- a/app/src/main/java/com/u1/slicer/network/MoonrakerClient.kt
+++ b/app/src/main/java/com/u1/slicer/network/MoonrakerClient.kt
@@ -165,7 +165,7 @@ class MoonrakerClient {
                 .connectTimeout(3, TimeUnit.SECONDS)
                 .readTimeout(3, TimeUnit.SECONDS)
                 .build()
-            val response = shortClient.newCall(Request.Builder().url(screenUrl).head().build()).execute()
+            val response = shortClient.newCall(Request.Builder().url(screenUrl).get().build()).execute()
             val ok = response.isSuccessful
             response.close()
             ok

--- a/app/src/main/java/com/u1/slicer/printer/PrinterRepository.kt
+++ b/app/src/main/java/com/u1/slicer/printer/PrinterRepository.kt
@@ -19,6 +19,13 @@ class PrinterRepository(
 
     private var pollingJob: Job? = null
 
+    /**
+     * When > 0 the polling loop uses 500 ms intervals instead of 2 000 ms.
+     * Decremented each cycle; when it reaches 0 normal polling resumes.
+     */
+    @Volatile
+    private var rapidPollCyclesRemaining = 0
+
     init {
         // Load saved printer URL
         CoroutineScope(Dispatchers.IO).launch {
@@ -52,7 +59,11 @@ class PrinterRepository(
         pollingJob = scope.launch(Dispatchers.IO) {
             while (isActive) {
                 _status.value = client.getStatus()
-                delay(2000)
+                val interval = if (rapidPollCyclesRemaining > 0) {
+                    rapidPollCyclesRemaining--
+                    500L
+                } else 2000L
+                delay(interval)
             }
         }
     }
@@ -66,7 +77,16 @@ class PrinterRepository(
         val uploadName = buildPrinterUploadFilename(filename)
         val uploaded = client.uploadGcode(gcodeFile, uploadName)
         if (!uploaded) return false
-        return client.startPrint(uploadName)
+        val started = client.startPrint(uploadName)
+        if (started) {
+            // Kick off rapid polling so the UI picks up the "printing" state
+            // as soon as Moonraker/Klipper transitions (PRINT_START macro may
+            // take several seconds on Snapmaker U1).  60 cycles × 500 ms = 30 s.
+            rapidPollCyclesRemaining = 60
+            // Immediate refresh so we don't wait for the next poll cycle.
+            _status.value = client.getStatus()
+        }
+        return started
     }
 
     suspend fun uploadOnly(gcodeFile: java.io.File, filename: String): Boolean {

--- a/app/src/main/java/com/u1/slicer/printer/PrinterViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/printer/PrinterViewModel.kt
@@ -98,6 +98,14 @@ class PrinterViewModel(application: Application) : AndroidViewModel(application)
         printerRepo.startPolling(viewModelScope)
         // Resolve webcam URLs for the already-saved printer URL (if any)
         viewModelScope.launch(Dispatchers.IO) { resolveWebcam() }
+        // Auto-clear the "Print started!" banner once the printer confirms printing.
+        viewModelScope.launch {
+            status.collect { s ->
+                if (_sendingState.value is SendingState.PrintStarted && s.isPrinting) {
+                    _sendingState.value = SendingState.Idle
+                }
+            }
+        }
     }
 
     fun updateUrl(url: String) {

--- a/app/src/main/java/com/u1/slicer/ui/PrinterScreen.kt
+++ b/app/src/main/java/com/u1/slicer/ui/PrinterScreen.kt
@@ -287,12 +287,14 @@ fun PrinterScreen(
                             Spacer(Modifier.width(8.dp))
                             Text("Print Status", fontWeight = FontWeight.Bold, fontSize = 16.sp)
                             Spacer(Modifier.weight(1f))
-                            val (badgeColor, badgeText) = when {
-                                status.isPrinting -> Color(0xFF4CAF50) to "PRINTING"
-                                status.isPaused   -> Color(0xFFFFC107) to "PAUSED"
-                                status.state == "complete" -> Color(0xFF2196F3) to "COMPLETE"
-                                status.state == "error"    -> Color(0xFFEF5350) to "ERROR"
-                                else -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f) to status.state.uppercase()
+                            val badgeText = resolveStatusBadge(status.state, sendingState is PrinterViewModel.SendingState.PrintStarted)
+                            val badgeColor = when (badgeText) {
+                                "PRINTING" -> Color(0xFF4CAF50)
+                                "PAUSED" -> Color(0xFFFFC107)
+                                "STARTING\u2026" -> Color(0xFF81C784)
+                                "COMPLETE" -> Color(0xFF2196F3)
+                                "ERROR" -> Color(0xFFEF5350)
+                                else -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
                             }
                             Surface(
                                 shape = RoundedCornerShape(6.dp),
@@ -764,5 +766,24 @@ private fun TempTile(
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f))
         }
+    }
+}
+
+/**
+ * Determine the status badge text for the Printer screen.
+ *
+ * When a print was just sent ([justSent] == true) but Moonraker hasn't
+ * transitioned to "printing" yet, we show "STARTING…" instead of the
+ * stale previous-print state (e.g. "CANCELLED").
+ */
+internal fun resolveStatusBadge(printerState: String, justSent: Boolean): String {
+    val staleStates = setOf("cancelled", "standby", "complete", "error")
+    return when {
+        printerState == "printing" -> "PRINTING"
+        printerState == "paused"   -> "PAUSED"
+        justSent && printerState in staleStates -> "STARTING\u2026"
+        printerState == "complete" -> "COMPLETE"
+        printerState == "error"    -> "ERROR"
+        else -> printerState.uppercase()
     }
 }

--- a/app/src/main/java/com/u1/slicer/viewer/GcodeRenderer.kt
+++ b/app/src/main/java/com/u1/slicer/viewer/GcodeRenderer.kt
@@ -15,9 +15,9 @@ import javax.microedition.khronos.opengles.GL10
 import kotlin.math.sqrt
 
 /**
- * Renders G-code toolpaths as 3D colored lines/ribbon quads.
- * Extrusion moves are rendered as flat ribbon quads (GL_TRIANGLES) when move count < 500K;
+ * Renders G-code toolpaths as 3D box-tube geometry (GL_TRIANGLES) when move count allows;
  * falls back to GL_LINES for very large files. Travel moves are always GL_LINES.
+ * Box tubes have top + left + right faces with proper normals for lighting.
  * All layers share a single VBO; each layer is a (firstVertex, count) range within it.
  */
 class GcodeRenderer(private val context: Context) : GLSurfaceView.Renderer {
@@ -74,7 +74,7 @@ class GcodeRenderer(private val context: Context) : GLSurfaceView.Renderer {
         floatArrayOf(0.0f, 0.9f, 0.4f, 1.0f),  // T2: green
         floatArrayOf(0.9f, 0.2f, 0.5f, 1.0f)   // T3: pink
     )
-    private val travelColor = floatArrayOf(0.3f, 0.3f, 0.3f, 0.4f)
+    private val travelColor = floatArrayOf(0.6f, 0.6f, 0.6f, 0.6f)
 
     // Feature-type color palette — indexed by FeatureType constants (0–11)
     private val featureTypeColors = arrayOf(
@@ -230,10 +230,11 @@ class GcodeRenderer(private val context: Context) : GLSurfaceView.Renderer {
         val tubeFloatsPerVertex = 10  // 3 pos + 4 color + 3 normal
         val maxBufferBytes = 80_000_000L  // 80MB limit per GPU buffer
 
-        // Decide whether to use ribbon quads for extrusions
-        // 6 vertices per move (2 triangles) * 10 floats * 4 bytes = 240 bytes per move
-        val tubeBytes = totalExtrudeMoves.toLong() * 6 * tubeFloatsPerVertex * 4
-        useTubes = totalExtrudeMoves < 500_000 && tubeBytes <= maxBufferBytes
+        // Decide whether to use box-tube geometry for extrusions
+        // 18 vertices per move (3 quads: top + left + right) * 10 floats * 4 bytes = 720 bytes per move
+        val verticesPerTubeMove = 18
+        val tubeBytes = totalExtrudeMoves.toLong() * verticesPerTubeMove * tubeFloatsPerVertex * 4
+        useTubes = totalExtrudeMoves < 200_000 && tubeBytes <= maxBufferBytes
 
         // --- Build line VBO (travels, and extrusion fallback when !useTubes) ---
         // Downsample extrusions if needed (only relevant in fallback path)
@@ -255,10 +256,11 @@ class GcodeRenderer(private val context: Context) : GLSurfaceView.Renderer {
         val lineData = FloatArray((estimatedLineMoves + estimatedTravelMoves) * 2 * floatsPerVertex + floatsPerVertex)
         var lineOffset = 0
 
-        // Allocate tube buffer: 6 vertices per extrusion move
-        val tubeData = if (useTubes) FloatArray(totalExtrudeMoves * 6 * tubeFloatsPerVertex) else FloatArray(0)
+        // Allocate tube buffer: 18 vertices per extrusion move (box-tube: top + left + right faces)
+        val tubeData = if (useTubes) FloatArray(totalExtrudeMoves * verticesPerTubeMove * tubeFloatsPerVertex) else FloatArray(0)
         var tubeOffset = 0
-        val halfWidth = 0.2f  // 0.4mm extrusion width / 2
+        val halfWidth = 0.225f  // 0.45mm extrusion width / 2
+        val halfHeight = 0.1f  // 0.2mm layer height / 2
 
         for ((layerIdx, layer) in gcode.layers.withIndex()) {
             // --- Extrusion pass ---
@@ -266,8 +268,9 @@ class GcodeRenderer(private val context: Context) : GLSurfaceView.Renderer {
             val tubeFirst = tubeOffset / tubeFloatsPerVertex
             var moveIdx = 0
 
-            // Per-layer brightness: even layers slightly darker, odd layers full brightness
-            val layerBrightness = if (layerIdx % 2 == 0) 0.85f else 1.0f
+            // Bottom-to-top brightness gradient: dark at bottom, bright at top (like u1-slicer-bridge)
+            val layerBrightness = if (totalLayers <= 1) 1.0f
+                else 0.45f + 0.55f * (layerIdx.toFloat() / (totalLayers - 1))
 
             for (move in layer.moves) {
                 if (move.type != MoveType.EXTRUDE) continue
@@ -284,51 +287,92 @@ class GcodeRenderer(private val context: Context) : GLSurfaceView.Renderer {
                 )
 
                 if (useTubes) {
-                    // Ribbon quad: 6 vertices (2 triangles)
+                    // Box-tube: 3 faces (top + left + right) = 18 vertices
                     val dx = move.x1 - move.x0
                     val dy = move.y1 - move.y0
                     val len = sqrt((dx * dx + dy * dy).toDouble()).toFloat()
                     if (len < 0.001f) continue  // skip zero-length moves
 
+                    // Perpendicular offset (left/right of move direction)
                     val px = -dy / len * halfWidth
                     val py = dx / len * halfWidth
-                    val z = layer.z
+                    val zBot = layer.z - halfHeight
+                    val zTop = layer.z + halfHeight
 
-                    // v0: x0-px, y0-py   v1: x0+px, y0+py
-                    // v3: x1-px, y1-py   v2: x1+px, y1+py
-                    // Tri1: v0, v1, v2   Tri2: v0, v2, v3
-                    if (tubeOffset + 6 * tubeFloatsPerVertex > tubeData.size) break
+                    if (tubeOffset + verticesPerTubeMove * tubeFloatsPerVertex > tubeData.size) break
 
-                    // Normal: perpendicular to move direction with slight outward tilt
-                    val nx = px / halfWidth * 0.3f
-                    val ny = py / halfWidth * 0.3f
-                    val nz = 0.95f
+                    // Side normals: perpendicular to move direction, horizontal
+                    val snx = px / halfWidth  // unit normal pointing right
+                    val sny = py / halfWidth
 
-                    // v0
-                    tubeData[tubeOffset++] = move.x0 - px; tubeData[tubeOffset++] = move.y0 - py; tubeData[tubeOffset++] = z
+                    // === Top face (normal pointing up: 0,0,1) ===
+                    // BL=x0-px,top  BR=x0+px,top  TR=x1+px,top  TL=x1-px,top
+                    // Tri1: BL, BR, TR
+                    tubeData[tubeOffset++] = move.x0 - px; tubeData[tubeOffset++] = move.y0 - py; tubeData[tubeOffset++] = zTop
                     tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
-                    tubeData[tubeOffset++] = -nx; tubeData[tubeOffset++] = -ny; tubeData[tubeOffset++] = nz
-                    // v1
-                    tubeData[tubeOffset++] = move.x0 + px; tubeData[tubeOffset++] = move.y0 + py; tubeData[tubeOffset++] = z
+                    tubeData[tubeOffset++] = 0f; tubeData[tubeOffset++] = 0f; tubeData[tubeOffset++] = 1f
+                    tubeData[tubeOffset++] = move.x0 + px; tubeData[tubeOffset++] = move.y0 + py; tubeData[tubeOffset++] = zTop
                     tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
-                    tubeData[tubeOffset++] = nx; tubeData[tubeOffset++] = ny; tubeData[tubeOffset++] = nz
-                    // v2
-                    tubeData[tubeOffset++] = move.x1 + px; tubeData[tubeOffset++] = move.y1 + py; tubeData[tubeOffset++] = z
+                    tubeData[tubeOffset++] = 0f; tubeData[tubeOffset++] = 0f; tubeData[tubeOffset++] = 1f
+                    tubeData[tubeOffset++] = move.x1 + px; tubeData[tubeOffset++] = move.y1 + py; tubeData[tubeOffset++] = zTop
                     tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
-                    tubeData[tubeOffset++] = nx; tubeData[tubeOffset++] = ny; tubeData[tubeOffset++] = nz
-                    // Tri2
-                    // v0 again
-                    tubeData[tubeOffset++] = move.x0 - px; tubeData[tubeOffset++] = move.y0 - py; tubeData[tubeOffset++] = z
+                    tubeData[tubeOffset++] = 0f; tubeData[tubeOffset++] = 0f; tubeData[tubeOffset++] = 1f
+                    // Tri2: BL, TR, TL
+                    tubeData[tubeOffset++] = move.x0 - px; tubeData[tubeOffset++] = move.y0 - py; tubeData[tubeOffset++] = zTop
                     tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
-                    tubeData[tubeOffset++] = -nx; tubeData[tubeOffset++] = -ny; tubeData[tubeOffset++] = nz
-                    // v2 again
-                    tubeData[tubeOffset++] = move.x1 + px; tubeData[tubeOffset++] = move.y1 + py; tubeData[tubeOffset++] = z
+                    tubeData[tubeOffset++] = 0f; tubeData[tubeOffset++] = 0f; tubeData[tubeOffset++] = 1f
+                    tubeData[tubeOffset++] = move.x1 + px; tubeData[tubeOffset++] = move.y1 + py; tubeData[tubeOffset++] = zTop
                     tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
-                    tubeData[tubeOffset++] = nx; tubeData[tubeOffset++] = ny; tubeData[tubeOffset++] = nz
-                    // v3
-                    tubeData[tubeOffset++] = move.x1 - px; tubeData[tubeOffset++] = move.y1 - py; tubeData[tubeOffset++] = z
+                    tubeData[tubeOffset++] = 0f; tubeData[tubeOffset++] = 0f; tubeData[tubeOffset++] = 1f
+                    tubeData[tubeOffset++] = move.x1 - px; tubeData[tubeOffset++] = move.y1 - py; tubeData[tubeOffset++] = zTop
                     tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
-                    tubeData[tubeOffset++] = -nx; tubeData[tubeOffset++] = -ny; tubeData[tubeOffset++] = nz
+                    tubeData[tubeOffset++] = 0f; tubeData[tubeOffset++] = 0f; tubeData[tubeOffset++] = 1f
+
+                    // === Right face (normal pointing right: snx, sny, 0) ===
+                    // BotStart=x0+px,bot  TopStart=x0+px,top  TopEnd=x1+px,top  BotEnd=x1+px,bot
+                    // Tri1: BotStart, TopStart, TopEnd
+                    tubeData[tubeOffset++] = move.x0 + px; tubeData[tubeOffset++] = move.y0 + py; tubeData[tubeOffset++] = zBot
+                    tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
+                    tubeData[tubeOffset++] = snx; tubeData[tubeOffset++] = sny; tubeData[tubeOffset++] = 0f
+                    tubeData[tubeOffset++] = move.x0 + px; tubeData[tubeOffset++] = move.y0 + py; tubeData[tubeOffset++] = zTop
+                    tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
+                    tubeData[tubeOffset++] = snx; tubeData[tubeOffset++] = sny; tubeData[tubeOffset++] = 0f
+                    tubeData[tubeOffset++] = move.x1 + px; tubeData[tubeOffset++] = move.y1 + py; tubeData[tubeOffset++] = zTop
+                    tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
+                    tubeData[tubeOffset++] = snx; tubeData[tubeOffset++] = sny; tubeData[tubeOffset++] = 0f
+                    // Tri2: BotStart, TopEnd, BotEnd
+                    tubeData[tubeOffset++] = move.x0 + px; tubeData[tubeOffset++] = move.y0 + py; tubeData[tubeOffset++] = zBot
+                    tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
+                    tubeData[tubeOffset++] = snx; tubeData[tubeOffset++] = sny; tubeData[tubeOffset++] = 0f
+                    tubeData[tubeOffset++] = move.x1 + px; tubeData[tubeOffset++] = move.y1 + py; tubeData[tubeOffset++] = zTop
+                    tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
+                    tubeData[tubeOffset++] = snx; tubeData[tubeOffset++] = sny; tubeData[tubeOffset++] = 0f
+                    tubeData[tubeOffset++] = move.x1 + px; tubeData[tubeOffset++] = move.y1 + py; tubeData[tubeOffset++] = zBot
+                    tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
+                    tubeData[tubeOffset++] = snx; tubeData[tubeOffset++] = sny; tubeData[tubeOffset++] = 0f
+
+                    // === Left face (normal pointing left: -snx, -sny, 0) ===
+                    // BotStart=x0-px,bot  TopStart=x0-px,top  TopEnd=x1-px,top  BotEnd=x1-px,bot
+                    // Tri1: BotStart, TopEnd, TopStart (wound CCW from outside)
+                    tubeData[tubeOffset++] = move.x0 - px; tubeData[tubeOffset++] = move.y0 - py; tubeData[tubeOffset++] = zBot
+                    tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
+                    tubeData[tubeOffset++] = -snx; tubeData[tubeOffset++] = -sny; tubeData[tubeOffset++] = 0f
+                    tubeData[tubeOffset++] = move.x1 - px; tubeData[tubeOffset++] = move.y1 - py; tubeData[tubeOffset++] = zTop
+                    tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
+                    tubeData[tubeOffset++] = -snx; tubeData[tubeOffset++] = -sny; tubeData[tubeOffset++] = 0f
+                    tubeData[tubeOffset++] = move.x0 - px; tubeData[tubeOffset++] = move.y0 - py; tubeData[tubeOffset++] = zTop
+                    tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
+                    tubeData[tubeOffset++] = -snx; tubeData[tubeOffset++] = -sny; tubeData[tubeOffset++] = 0f
+                    // Tri2: BotStart, BotEnd, TopEnd
+                    tubeData[tubeOffset++] = move.x0 - px; tubeData[tubeOffset++] = move.y0 - py; tubeData[tubeOffset++] = zBot
+                    tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
+                    tubeData[tubeOffset++] = -snx; tubeData[tubeOffset++] = -sny; tubeData[tubeOffset++] = 0f
+                    tubeData[tubeOffset++] = move.x1 - px; tubeData[tubeOffset++] = move.y1 - py; tubeData[tubeOffset++] = zBot
+                    tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
+                    tubeData[tubeOffset++] = -snx; tubeData[tubeOffset++] = -sny; tubeData[tubeOffset++] = 0f
+                    tubeData[tubeOffset++] = move.x1 - px; tubeData[tubeOffset++] = move.y1 - py; tubeData[tubeOffset++] = zTop
+                    tubeData[tubeOffset++] = color[0]; tubeData[tubeOffset++] = color[1]; tubeData[tubeOffset++] = color[2]; tubeData[tubeOffset++] = color[3]
+                    tubeData[tubeOffset++] = -snx; tubeData[tubeOffset++] = -sny; tubeData[tubeOffset++] = 0f
                 } else {
                     // Fallback: GL_LINES
                     if (sampleRate > 1 && moveIdx++ % sampleRate != 0) continue

--- a/app/src/test/java/com/u1/slicer/ui/PrinterStatusBadgeTest.kt
+++ b/app/src/test/java/com/u1/slicer/ui/PrinterStatusBadgeTest.kt
@@ -1,0 +1,93 @@
+package com.u1.slicer.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tests for [resolveStatusBadge] — the badge text shown on the Printer screen.
+ *
+ * Key scenario: after a print is sent ("Print started!" banner visible),
+ * Moonraker may still report the previous print's state (e.g. "cancelled")
+ * until the PRINT_START macro finishes.  The badge should show "STARTING…"
+ * instead of the stale state.
+ */
+class PrinterStatusBadgeTest {
+
+    // ── Normal (no pending send) ───────────────────────────────────────
+
+    @Test
+    fun `printing state shows PRINTING`() {
+        assertEquals("PRINTING", resolveStatusBadge("printing", justSent = false))
+    }
+
+    @Test
+    fun `paused state shows PAUSED`() {
+        assertEquals("PAUSED", resolveStatusBadge("paused", justSent = false))
+    }
+
+    @Test
+    fun `complete state shows COMPLETE`() {
+        assertEquals("COMPLETE", resolveStatusBadge("complete", justSent = false))
+    }
+
+    @Test
+    fun `error state shows ERROR`() {
+        assertEquals("ERROR", resolveStatusBadge("error", justSent = false))
+    }
+
+    @Test
+    fun `standby state shows STANDBY`() {
+        assertEquals("STANDBY", resolveStatusBadge("standby", justSent = false))
+    }
+
+    @Test
+    fun `cancelled state shows CANCELLED`() {
+        assertEquals("CANCELLED", resolveStatusBadge("cancelled", justSent = false))
+    }
+
+    @Test
+    fun `disconnected state shows DISCONNECTED`() {
+        assertEquals("DISCONNECTED", resolveStatusBadge("disconnected", justSent = false))
+    }
+
+    // ── Just-sent: stale states overridden to STARTING ─────────────────
+
+    @Test
+    fun `justSent with cancelled shows STARTING`() {
+        assertEquals("STARTING\u2026", resolveStatusBadge("cancelled", justSent = true))
+    }
+
+    @Test
+    fun `justSent with standby shows STARTING`() {
+        assertEquals("STARTING\u2026", resolveStatusBadge("standby", justSent = true))
+    }
+
+    @Test
+    fun `justSent with complete shows STARTING`() {
+        assertEquals("STARTING\u2026", resolveStatusBadge("complete", justSent = true))
+    }
+
+    @Test
+    fun `justSent with error shows STARTING`() {
+        assertEquals("STARTING\u2026", resolveStatusBadge("error", justSent = true))
+    }
+
+    // ── Just-sent: non-stale states are NOT overridden ─────────────────
+
+    @Test
+    fun `justSent with printing still shows PRINTING`() {
+        assertEquals("PRINTING", resolveStatusBadge("printing", justSent = true))
+    }
+
+    @Test
+    fun `justSent with paused still shows PAUSED`() {
+        assertEquals("PAUSED", resolveStatusBadge("paused", justSent = true))
+    }
+
+    @Test
+    fun `justSent with disconnected shows DISCONNECTED not STARTING`() {
+        // "disconnected" is not in the stale-state list — if the printer
+        // genuinely lost connection, we should show that, not mask it.
+        assertEquals("DISCONNECTED", resolveStatusBadge("disconnected", justSent = true))
+    }
+}


### PR DESCRIPTION
## Summary
- **B36**: Fix confusing "Loading Downloading from MakerWorld……" text — each loading state provides a complete display message
- **F37**: File picker no longer shows all file types — removed `*/*` wildcard, filters to 3MF/STL/OBJ only
- **F38**: G-code preview upgraded from flat ribbons to box-tube geometry (top + left + right faces with proper normals) and bottom-to-top brightness gradient matching u1-slicer-bridge
- **F39**: Travel move toggle (eye icon) added to inline Preview screen with brighter travel line color — was previously only in full-screen view
- Printer status badge and upload filename improvements

## Test plan
- [x] 482/482 JVM unit tests pass
- [x] 116/118 instrumented tests pass (2 pre-existing flaky failures in PreparePreviewViewModelTest — Dragon plate 3 OOM crash + slip/slide timeout, unrelated to this PR)
- [x] E2E: G-code preview renders with box-tube geometry, brightness gradient visible
- [x] E2E: Travel toggle and fullscreen buttons visible at bottom-right of preview (not hidden under action bar)
- [ ] Manual: verify file picker filters correctly on device
- [ ] Manual: verify MakerWorld import shows correct loading text

🤖 Generated with [Claude Code](https://claude.com/claude-code)