### PR TITLE
fix: file picker regression — validate extension instead of filtering MIME types

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -36,7 +36,7 @@ Open bugs, features, and investigations. Everything else is done — see git log
 ## Closed (recent)
 See git log for full history. Most recent fixes:
 - **B36**: MakerWorld download/loading text was confusing ("Loading Downloading from MakerWorld……") — each state now provides complete display message — FIXED v1.4.22
-- **F37**: File picker showed all file types — removed `*/*` wildcard, now filters to 3MF/STL/OBJ only — DONE v1.4.22
+- **F37**: File picker accepted any file — now validates extension after selection and rejects unsupported types with a clear error message (`*/*` kept in MIME types since Android file managers don't recognize `model/*`) — DONE v1.4.22
 - **F38**: G-code preview upgraded to box-tube geometry (top + left + right faces) with bottom-to-top brightness gradient matching u1-slicer-bridge quality — DONE v1.4.22
 - **F39**: Travel move toggle added to inline G-code preview on Preview screen, brighter travel line color — DONE v1.4.22
 - **B31/F35**: Clipper coordinate overflow crash on multi-colour SEMM models — native overflow guards in `IntersectPoint` and `Round()`, Kotlin wipe tower clamping, crash-loop prevention, stale marker cleanup on APK upgrade — FIXED v1.4.20/v1.4.21

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,13 +49,13 @@ Public vulnerability reports should follow [`SECURITY.md`](SECURITY.md). Keep an
 ## Test
 
 ```bash
-./gradlew testDebugUnitTest                        # 482 JVM unit tests
+./gradlew testDebugUnitTest                        # 490 JVM unit tests
 ./gradlew connectedDebugAndroidTest                # 118 instrumented tests (uses Orchestrator)
 ```
 
 For local device IDs and any private E2E notes, consult `E2E_TESTING.local.md` if present.
 
-### Unit tests (`app/src/test/`) - 482 tests across 30 classes
+### Unit tests (`app/src/test/`) - 490 tests across 31 classes
 - `gcode/GcodeParserTest.kt` (26) — G-code parsing: layers, extrusion, extruder switching, ;TYPE: feature-type tagging, wipeTowerFilamentMm
 - `gcode/GcodeValidatorTest.kt` (41) — Tool changes, nozzle temps, layer count, prime tower footprint, bed bounds validation
 - `gcode/GcodeToolRemapperTest.kt` (19) — Compact tool index remapping, SM_ params, M104/M109
@@ -76,6 +76,7 @@ For local device IDs and any private E2E notes, consult `E2E_TESTING.local.md` i
 - `ui/FilamentJsonImportTest.kt` (15) — JSON import parsing: snake_case/camelCase, defaults, errors
 - `ui/MultiColorMappingTest.kt` (9) — ensureMultiSlotMapping collapse detection and sequential distribution
 - `ui/PrinterStatusBadgeTest.kt` (14) — Printer status badge text, color, and icon mapping for all printer states
+- `FilePickerValidationTest.kt` (8) — isSupportedFile extension matching for 3MF, STL, OBJ, STEP; rejects unsupported types
 - `model/CopyArrangeCalculatorTest.kt` (18) — Centered grid layout, bed bounds, copy capping, wipe tower auto-positioning, skirt clearance
 - `UpgradeDetectorTest.kt` (15) — APK upgrade detection logic, version/timestamp comparison, file clearing patterns
 - `DiagnosticsStoreTest.kt` (5) — Diagnostics event logging, JSONL output

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The native `.so` is pre-built and committed to `app/src/main/jniLibs/arm64-v8a/`
 ## Testing
 
 ```bash
-./gradlew testDebugUnitTest              # 482 JVM unit tests
+./gradlew testDebugUnitTest              # 490 JVM unit tests
 ./gradlew connectedDebugAndroidTest      # 118 instrumented tests (ARM64 device required)
 ```
 

--- a/app/src/main/java/com/u1/slicer/MainActivity.kt
+++ b/app/src/main/java/com/u1/slicer/MainActivity.kt
@@ -57,7 +57,14 @@ class MainActivity : ComponentActivity() {
     private val filePickerLauncher = registerForActivityResult(
         ActivityResultContracts.OpenDocument()
     ) { uri ->
-        uri?.let { viewModel.loadModel(it) }
+        uri?.let {
+            val name = viewModel.getFileDisplayName(it) ?: ""
+            if (name.isEmpty() || SlicerViewModel.isSupportedFile(name)) {
+                viewModel.loadModel(it)
+            } else {
+                viewModel.showUnsupportedFileError(name)
+            }
+        }
     }
 
     private val gcodeSaveLauncher = registerForActivityResult(
@@ -332,7 +339,8 @@ class MainActivity : ComponentActivity() {
                     "application/octet-stream",
                     "model/3mf",
                     "application/vnd.ms-3mfdocument",
-                    "model/obj"
+                    "model/obj",
+                    "*/*"  // fallback — Android file managers don't recognize model/* MIME types
                 )
 
                 U1NavGraph(

--- a/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
@@ -1909,6 +1909,18 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
         }
     }
 
+    /** Public accessor for file picker validation in MainActivity. */
+    fun getFileDisplayName(uri: Uri): String? =
+        getDisplayName(getApplication(), uri)
+
+    /** Show error for unsupported file type selected in the picker. */
+    fun showUnsupportedFileError(filename: String) {
+        val ext = filename.substringAfterLast('.', "")
+        _state.value = SlicerState.Error(
+            "Unsupported file type: .$ext\n\nPlease select a 3MF, STL, or OBJ file."
+        )
+    }
+
     private fun getDisplayName(context: android.content.Context, uri: Uri): String? {
         context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)?.use { cursor ->
             if (cursor.moveToFirst()) {
@@ -1920,6 +1932,15 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     companion object {
+        /** File extensions accepted by the file picker. */
+        val SUPPORTED_EXTENSIONS = setOf("3mf", "stl", "obj", "step", "stp")
+
+        /** Returns true if the filename has a supported 3D model extension. */
+        fun isSupportedFile(filename: String): Boolean {
+            val ext = filename.substringAfterLast('.', "").lowercase()
+            return ext in SUPPORTED_EXTENSIONS
+        }
+
         /**
          * Merges a sanitized ThreeMfInfo (processedInfo) with the original parse (origInfo).
          *

--- a/app/src/test/java/com/u1/slicer/FilePickerValidationTest.kt
+++ b/app/src/test/java/com/u1/slicer/FilePickerValidationTest.kt
@@ -1,0 +1,65 @@
+package com.u1.slicer
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FilePickerValidationTest {
+
+    @Test
+    fun `3mf files are supported`() {
+        assertTrue(SlicerViewModel.isSupportedFile("model.3mf"))
+        assertTrue(SlicerViewModel.isSupportedFile("My Model (1).3mf"))
+        assertTrue(SlicerViewModel.isSupportedFile("UPPERCASE.3MF"))
+    }
+
+    @Test
+    fun `stl files are supported`() {
+        assertTrue(SlicerViewModel.isSupportedFile("benchy.stl"))
+        assertTrue(SlicerViewModel.isSupportedFile("part.STL"))
+    }
+
+    @Test
+    fun `obj files are supported`() {
+        assertTrue(SlicerViewModel.isSupportedFile("mesh.obj"))
+        assertTrue(SlicerViewModel.isSupportedFile("MESH.OBJ"))
+    }
+
+    @Test
+    fun `step files are supported`() {
+        assertTrue(SlicerViewModel.isSupportedFile("cad-part.step"))
+        assertTrue(SlicerViewModel.isSupportedFile("assembly.stp"))
+        assertTrue(SlicerViewModel.isSupportedFile("model.STEP"))
+        assertTrue(SlicerViewModel.isSupportedFile("model.STP"))
+    }
+
+    @Test
+    fun `unsupported file types are rejected`() {
+        assertFalse(SlicerViewModel.isSupportedFile("photo.jpg"))
+        assertFalse(SlicerViewModel.isSupportedFile("document.pdf"))
+        assertFalse(SlicerViewModel.isSupportedFile("archive.zip"))
+        assertFalse(SlicerViewModel.isSupportedFile("text.txt"))
+        assertFalse(SlicerViewModel.isSupportedFile("spreadsheet.xlsx"))
+        assertFalse(SlicerViewModel.isSupportedFile("video.mp4"))
+        assertFalse(SlicerViewModel.isSupportedFile("code.gcode"))
+    }
+
+    @Test
+    fun `files without extension are rejected`() {
+        assertFalse(SlicerViewModel.isSupportedFile("noextension"))
+        assertFalse(SlicerViewModel.isSupportedFile(""))
+    }
+
+    @Test
+    fun `extension matching is case insensitive`() {
+        assertTrue(SlicerViewModel.isSupportedFile("mixed.3Mf"))
+        assertTrue(SlicerViewModel.isSupportedFile("mixed.Stl"))
+        assertTrue(SlicerViewModel.isSupportedFile("mixed.OBJ"))
+    }
+
+    @Test
+    fun `files with dots in name match on last extension`() {
+        assertTrue(SlicerViewModel.isSupportedFile("my.model.v2.3mf"))
+        assertFalse(SlicerViewModel.isSupportedFile("model.3mf.zip"))
+    }
+}


### PR DESCRIPTION
## Summary
- Restores `*/*` in file picker MIME types (Android doesn't recognize `model/3mf`)
- Validates file extension **after selection** — rejects unsupported types with clear error
- Adds `isSupportedFile()` companion method + 8 unit tests

## Test plan
- [x] 490/490 JVM unit tests pass (8 new FilePickerValidationTest)
- [ ] Manual: open file picker, select a .3mf file — loads correctly
- [ ] Manual: open file picker, select a .jpg file — shows "Unsupported file type" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)