### PR TITLE
refactor(B85): unify imported 3MF preparation path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ Public vulnerability reports should follow [`SECURITY.md`](SECURITY.md). Keep an
 
 ```bash
 ./gradlew testDebugUnitTest                        # 814 JVM unit tests
-./gradlew connectedDebugAndroidTest                # 180 instrumented tests (uses Orchestrator)
+./gradlew connectedDebugAndroidTest                # 181 instrumented tests (uses Orchestrator)
 ```
 
 For local device IDs and any private E2E notes, consult `E2E_TESTING.local.md` if present.
@@ -119,7 +119,7 @@ For local device IDs and any private E2E notes, consult `E2E_TESTING.local.md` i
 - `NozzleTempDefaultTest.kt` (11+7=18) — nozzleTempDefaultForMaterial per-material defaults + ComputeFreshExtruderTempsTest: preset→temp lookup, filament profile ID priority, usedSlots remap, stale-config regression (v1.5.63)
 - `bambu/BambuSanitizerMetadataPreservationTest.kt` (2) — B77: per-object non-extruder metadata (enable_support, support_type, seam_position, layer_height) preserved through sanitizer no-rewrite branch
 
-### Instrumented tests (`app/src/androidTest/`) - 179 tests across 18 classes
+### Instrumented tests (`app/src/androidTest/`) - 180 tests across 18 classes
 - `data/FilamentDaoTest.kt` (9) — Room DAO CRUD, ordering, count
 - `data/SliceJobDaoTest.kt` (8) — Room DAO insert, ordering, delete, sourcePath null default, round-trip, updateSourcePath
 - `data/GcodeSaveTruncationTest.kt` (2) — Save truncation regression
@@ -134,7 +134,7 @@ For local device IDs and any private E2E notes, consult `E2E_TESTING.local.md` i
 - `gcode/GcodeThumbnailInjectorTest.kt` (8) — 3MF image extraction, thumbnail blocks, G-code injection
 - `viewer/NativePreparePreviewTest.kt` (16) — native Prepare preview regressions: dual-colour, painted, old asset, selected multi-plate spread, Dragon plate 3 colour preservation, H2C benchy full/decimated 7-index preservation + green recolor + interleaving guard, layer-tool Z-band recolor, triangle count cap, B51 old.3mf bounding box + Korok orientation, B72 multi-instance post-slice bounds, B78 Shashibo plate 5 file-scale+centre preservation on fresh load + post-slice dirty-path reset
 - `viewer/ThreeMfMeshParserTest.kt` (4) - 3MF mesh parsing, transform resolution, per-triangle color extraction, calicube extruder indices
-- `PreparePreviewViewModelTest.kt` (6) — Dragon plate 3 end-to-end Prepare state, slice-output colour coverage, H2C benchy full pipeline green verification, B47 colorMapping-before-ModelLoaded ordering contract, B83 plate-switch objectIds stable-source fix
+- `PreparePreviewViewModelTest.kt` (7) — Dragon plate 3 end-to-end Prepare state, slice-output colour coverage, H2C benchy full pipeline green verification, B47 colorMapping-before-ModelLoaded ordering contract, B83 plate-switch objectIds stable-source fix, entry-point equivalence for `loadModel(uri)` vs `loadModelFromFile(file)`
 - `ui/MakerWorldBrowserUtilsInstrumentedTest.kt` (6) — resolveDownloadFilename with URLUtil, RFC 5987, path traversal sanitization
 
 ### Red-green TDD for bug fixes
@@ -143,7 +143,7 @@ When fixing visual or pipeline bugs (preview colours, G-code output, colour mapp
 
 1. **Red**: Write a failing instrumented test that reproduces the bug programmatically. The test must fail on the current code and assert the correct behaviour.
 2. **Green**: Fix the code until the test passes.
-3. **Verify**: Run the test on-device (`connectedDebugAndroidTest --tests "..."`) — do not rely on screenshots or manual inspection.
+3. **Verify**: Run the test on-device (`connectedDebugAndroidTest "-Pandroid.testInstrumentationRunnerArguments.class=com.u1.slicer.TestClass#testMethod"`) — do not rely on screenshots or manual inspection.
 
 **Why**: Screenshots at default zoom are unreliable. Manual visual checks can't be repeated. Programmatic tests catch regressions automatically.
 

--- a/app/src/androidTest/java/com/u1/slicer/PreparePreviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/u1/slicer/PreparePreviewViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.u1.slicer
 
+import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import kotlinx.coroutines.CoroutineScope
@@ -14,6 +15,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.File
+import java.util.zip.ZipFile
 
 @RunWith(AndroidJUnit4::class)
 class PreparePreviewViewModelTest {
@@ -292,12 +294,113 @@ class PreparePreviewViewModelTest {
         }
     }
 
+    @Test
+    fun dragonScale_importViaUri_matchesDirectFilePipelineArtifacts() {
+        val application = targetContext.applicationContext as U1SlicerApplication
+        val fileViewModel = SlicerViewModel(application)
+        val uriViewModel = SlicerViewModel(application)
+        val modelFile = copyAssetToCache("Dragon Scale infinity.3mf")
+
+        try {
+            fileViewModel.loadModelFromFile(modelFile)
+
+            waitUntil("direct-file import reaches prepared multi-plate state", timeoutMs = 90_000L) {
+                fileViewModel.showPlateSelector.value &&
+                    fileViewModel.threeMfInfo.value != null &&
+                    fileViewModel.currentModelPath != null
+            }
+
+            val fileInfo = fileViewModel.threeMfInfo.value!!
+            val fileSourceConfig = fileViewModel.sourceConfig.value
+            val fileEntryNames = zipEntryNames(File(fileViewModel.currentModelPath!!))
+            val fileProjectSettingsCount = zipEntryCount(
+                File(fileViewModel.currentModelPath!!),
+                "Metadata/project_settings.config"
+            )
+            val fileShowPlateSelector = fileViewModel.showPlateSelector.value
+
+            fileViewModel.clearModel()
+            uriViewModel.loadModel(Uri.fromFile(modelFile))
+
+            waitUntil("uri import reaches prepared multi-plate state", timeoutMs = 90_000L) {
+                uriViewModel.showPlateSelector.value &&
+                    uriViewModel.threeMfInfo.value != null &&
+                    uriViewModel.currentModelPath != null
+            }
+
+            val uriInfo = uriViewModel.threeMfInfo.value!!
+            val uriSourceConfig = uriViewModel.sourceConfig.value
+            val uriEntryNames = zipEntryNames(File(uriViewModel.currentModelPath!!))
+            val uriProjectSettingsCount = zipEntryCount(
+                File(uriViewModel.currentModelPath!!),
+                "Metadata/project_settings.config"
+            )
+            val uriShowPlateSelector = uriViewModel.showPlateSelector.value
+
+            assertTrue("Dragon Scale should be Bambu in direct-file path", fileInfo.isBambu)
+            assertTrue("Dragon Scale should be Bambu in uri path", uriInfo.isBambu)
+            assertTrue("Dragon Scale should show plate selector for direct-file path", fileShowPlateSelector)
+            assertTrue("Dragon Scale should show plate selector for uri path", uriShowPlateSelector)
+
+            assertEquals("isMultiPlate must match across import paths", fileInfo.isMultiPlate, uriInfo.isMultiPlate)
+            assertEquals(
+                "detectedExtruderCount must match across import paths",
+                fileInfo.detectedExtruderCount,
+                uriInfo.detectedExtruderCount
+            )
+            assertEquals("hasPaintData must match across import paths", fileInfo.hasPaintData, uriInfo.hasPaintData)
+            assertEquals(
+                "hasLayerToolChanges must match across import paths",
+                fileInfo.hasLayerToolChanges,
+                uriInfo.hasLayerToolChanges
+            )
+            assertEquals("detectedColors must match across import paths", fileInfo.detectedColors, uriInfo.detectedColors)
+            assertEquals(
+                "plate ids must match across import paths",
+                fileInfo.plates.map { it.plateId },
+                uriInfo.plates.map { it.plateId }
+            )
+            assertEquals(
+                "sourceConfig must match across import paths",
+                fileSourceConfig,
+                uriSourceConfig
+            )
+            assertEquals(
+                "embedded ZIP entry set must match across import paths",
+                fileEntryNames,
+                uriEntryNames
+            )
+            assertEquals(
+                "embedded direct-file import must contain exactly one project_settings.config",
+                1,
+                fileProjectSettingsCount
+            )
+            assertEquals(
+                "embedded uri import must contain exactly one project_settings.config",
+                1,
+                uriProjectSettingsCount
+            )
+        } finally {
+            fileViewModel.clearModel()
+            uriViewModel.clearModel()
+            modelFile.delete()
+        }
+    }
+
     private fun copyAssetToCache(assetName: String): File {
         val outFile = File(targetContext.cacheDir, assetName.replace("/", "_"))
         assetContext.assets.open(assetName).use { input ->
             outFile.outputStream().use { output -> input.copyTo(output) }
         }
         return outFile
+    }
+
+    private fun zipEntryNames(file: File): Set<String> = ZipFile(file).use { zip ->
+        zip.entries().asSequence().map { it.name }.toSet()
+    }
+
+    private fun zipEntryCount(file: File, entryName: String): Int = ZipFile(file).use { zip ->
+        zip.entries().asSequence().count { it.name == entryName }
     }
 
     /**

--- a/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
@@ -122,6 +122,27 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
         val instanceCount: Int
     )
 
+    /**
+     * Shared 3MF import pipeline contract for loadModel(uri), loadModelFromFile(file),
+     * and MakerWorld imports.
+     *
+     * rawFile is the durable pre-sanitize copy retained for recovery. processedFile is the
+     * sanitize/deferred-restructure artifact kept for later plate extraction and re-embed.
+     * embeddedFile is the current profile-embedded artifact loaded into native code.
+     */
+    private data class PreparedModelArtifacts(
+        val rawFile: File,
+        val origInfo: ThreeMfInfo,
+        val sourceConfig: Map<String, Any>?,
+        val processedFile: File,
+        val processedInfo: ThreeMfInfo,
+        val mergedInfo: ThreeMfInfo,
+        val embeddedFile: File
+    ) {
+        val requiresPlateSelection: Boolean
+            get() = origInfo.isMultiPlate && origInfo.plates.size > 1
+    }
+
     private val native = NativeLibrary()
     private val diagnostics = DiagnosticsStore(application)
     private val container = (application as U1SlicerApplication).container
@@ -658,34 +679,22 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
                 recoveryPlateId = -1
                 _state.value = SlicerState.Loading("Preparing model…")
 
-                // Same pipeline as loadModel(): parse → sanitize → embed → load
-                val origInfo = ThreeMfParser.parse(outputFile)
-                recoveryOrigInfo = origInfo  // Saved for Clipper recovery pipeline
-                _sourceConfig.value = if (origInfo.isBambu) {
-                    java.util.zip.ZipFile(outputFile).use { profileEmbedder.parseSourceConfig(it) }
-                } else null
+                val prepared = prepareImportedModelArtifacts(outputFile, workspaceDir)
 
-                val processed = BambuSanitizer.process(outputFile, workspaceDir, isBambu = origInfo.isBambu)
-                val processedInfo = ThreeMfParser.parse(processed, skipPaintDetection = true)
-                _threeMfInfo.value = mergeThreeMfInfo(processedInfo, origInfo)
-                _fileThreeMfInfo = _threeMfInfo.value
-
-                sourceModelFile = processed
-                sourceModelInfo = processedInfo
-                if (origInfo.isMultiPlate) _multiPlateSourceFile = processed
-                toolRemapSlots = null
-                semmColorPermutation = null
-                val mergedInfo = _threeMfInfo.value!!
-                val sanitized = embedProfile(processed, mergedInfo, workspaceDir)
-
-                currentModelFile = sanitized
-                if (origInfo.isMultiPlate && origInfo.plates.size > 1) {
-                    Log.i("SlicerVM", "MakerWorld file is multi-plate (${origInfo.plates.size} plates), showing selector")
+                currentModelFile = prepared.embeddedFile
+                if (prepared.requiresPlateSelection) {
+                    Log.i(
+                        "SlicerVM",
+                        "MakerWorld file is multi-plate (${prepared.origInfo.plates.size} plates), showing selector"
+                    )
                     _showPlateSelector.value = true
                     return@launch
                 }
-                Log.i("SlicerVM", "Loading MakerWorld model natively: ${sanitized.name} (${sanitized.length()} bytes)")
-                loadNativeModel(sanitized)
+                Log.i(
+                    "SlicerVM",
+                    "Loading MakerWorld model natively: ${prepared.embeddedFile.name} (${prepared.embeddedFile.length()} bytes)"
+                )
+                loadNativeModel(prepared.embeddedFile)
             } catch (e: Throwable) {
                 NativeLibrary.previewMutex.withLock { native.clearModel() }
                 _state.value = SlicerState.Error(e.message ?: "Import failed")
@@ -777,10 +786,8 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
                         )
                     }
 
-                    // Parse original file first for multi-plate detection (process()
-                    // strips plate_N.json so detection would fail on the processed file).
-                    val origInfo = ThreeMfParser.parse(file)
-                    recoveryOrigInfo = origInfo  // Saved for Clipper recovery pipeline
+                    val prepared = prepareImportedModelArtifacts(file, workspaceDir)
+                    val origInfo = prepared.origInfo
 
                     Log.i("SlicerVM", "3MF: bambu=${origInfo.isBambu}, multiPlate=${origInfo.isMultiPlate}, " +
                         "colors=${origInfo.detectedColors.size}, extruders=${origInfo.detectedExtruderCount}, " +
@@ -804,45 +811,18 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
                         )
                     )
 
-                    // Parse original file's config BEFORE process() strips it.
-                    // This preserves file-level settings (enable_support, etc.) through the pipeline.
-                    _sourceConfig.value = if (origInfo.isBambu) {
-                        java.util.zip.ZipFile(file).use { profileEmbedder.parseSourceConfig(it) }
-                    } else null
-
-                    // Sanitize first (strip printable="0", restructure multi-color, clean XML),
-                    // then embed Snapmaker profile.  Without process(), non-printable build
-                    // items cause "Coordinate outside allowed range" Clipper errors.
-                val processed = BambuSanitizer.process(file, workspaceDir, isBambu = origInfo.isBambu)
-                    val processedInfo = ThreeMfParser.parse(processed, skipPaintDetection = true)
-                    _threeMfInfo.value = mergeThreeMfInfo(processedInfo, origInfo)
-                    _fileThreeMfInfo = _threeMfInfo.value
-
-                    // Store source before embedding so startSlicing() can re-embed with
-                    // the correct extruder remap once the user has picked their slots.
-                    sourceModelFile = processed
-                    sourceModelInfo = processedInfo
-                    if (origInfo.isMultiPlate) _multiPlateSourceFile = processed
-                    toolRemapSlots = null  // reset on each new file load
-                    semmColorPermutation = null
-                    // Use merged info (preserves origInfo's extruder count, paint data, etc.)
-                    // so the preserve path in buildConfig() activates correctly for Bambu files
-                    // with multi-extruder assignments (needed for support preservation — B10 fix).
-                    val mergedInfo = _threeMfInfo.value!!
-                    val sanitized = embedProfile(processed, mergedInfo, workspaceDir)
-
                     // Show plate selector for multi-plate files (use origInfo since
                     // process() strips plate_N.json files that isMultiPlate relies on).
-                    if (origInfo.isMultiPlate && origInfo.plates.size > 1) {
+                    if (prepared.requiresPlateSelection) {
                         Log.i("SlicerVM", "Multi-plate: ${origInfo.plates.size} plates, showing selector")
-                        currentModelFile = sanitized
+                        currentModelFile = prepared.embeddedFile
                         _showPlateSelector.value = true
                         // Don't load yet — wait for plate selection
                         return@launch
                     }
                     Log.i("SlicerVM", "Single-plate, loading directly")
 
-                    sanitized
+                    prepared.embeddedFile
                 } else {
                     _threeMfInfo.value = null
                     recoveryOrigInfo = null  // STL: no 3MF pipeline needed for recovery
@@ -971,8 +951,8 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
                         )
                     }
 
-                    val origInfo = ThreeMfParser.parse(sourceFile)
-                    recoveryOrigInfo = origInfo
+                    val prepared = prepareImportedModelArtifacts(sourceFile, workspaceDir)
+                    val origInfo = prepared.origInfo
 
                     Log.i("SlicerVM", "3MF: bambu=${origInfo.isBambu}, multiPlate=${origInfo.isMultiPlate}, " +
                         "colors=${origInfo.detectedColors.size}, extruders=${origInfo.detectedExtruderCount}, " +
@@ -994,32 +974,15 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
                         )
                     )
 
-                    _sourceConfig.value = if (origInfo.isBambu) {
-                        java.util.zip.ZipFile(sourceFile).use { profileEmbedder.parseSourceConfig(it) }
-                    } else null
-
-                    val processed = BambuSanitizer.process(sourceFile, workspaceDir, isBambu = origInfo.isBambu)
-                    val processedInfo = ThreeMfParser.parse(processed, skipPaintDetection = true)
-                    _threeMfInfo.value = mergeThreeMfInfo(processedInfo, origInfo)
-                    _fileThreeMfInfo = _threeMfInfo.value
-
-                    sourceModelFile = processed
-                    sourceModelInfo = processedInfo
-                    if (origInfo.isMultiPlate) _multiPlateSourceFile = processed
-                    toolRemapSlots = null
-                    semmColorPermutation = null
-                    val mergedInfo = _threeMfInfo.value!!
-                    val sanitized = embedProfile(processed, mergedInfo, workspaceDir)
-
-                    if (origInfo.isMultiPlate && origInfo.plates.size > 1) {
+                    if (prepared.requiresPlateSelection) {
                         Log.i("SlicerVM", "Multi-plate: ${origInfo.plates.size} plates, showing selector")
-                        currentModelFile = sanitized
+                        currentModelFile = prepared.embeddedFile
                         _showPlateSelector.value = true
                         return@launch
                     }
                     Log.i("SlicerVM", "Single-plate, loading directly")
 
-                    sanitized
+                    prepared.embeddedFile
                 } else {
                     _threeMfInfo.value = null
                     recoveryOrigInfo = null
@@ -1588,6 +1551,46 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
         saveSlicingOverrides(slicingOverrides.value.copy(primeTower = newOverride))
         invalidatePrepareMeshCache()
         _sliceStale.value = true
+    }
+
+    /**
+     * Runs the shared 3MF preparation path used by all import entry points:
+     * parse original metadata, capture file-level config, sanitize/defer restructure,
+     * merge stage metadata, then embed the active Snapmaker profile.
+     */
+    private fun prepareImportedModelArtifacts(sourceFile: File, workspaceDir: File): PreparedModelArtifacts {
+        val origInfo = ThreeMfParser.parse(sourceFile)
+        recoveryOrigInfo = origInfo
+
+        val sourceConfig = if (origInfo.isBambu) {
+            ZipFile(sourceFile).use { profileEmbedder.parseSourceConfig(it) }
+        } else {
+            null
+        }
+        _sourceConfig.value = sourceConfig
+
+        val processed = BambuSanitizer.process(sourceFile, workspaceDir, isBambu = origInfo.isBambu)
+        val processedInfo = ThreeMfParser.parse(processed, skipPaintDetection = true)
+        val mergedInfo = mergeThreeMfInfo(processedInfo, origInfo)
+
+        _threeMfInfo.value = mergedInfo
+        _fileThreeMfInfo = mergedInfo
+        sourceModelFile = processed
+        sourceModelInfo = processedInfo
+        if (origInfo.isMultiPlate) _multiPlateSourceFile = processed
+        toolRemapSlots = null
+        semmColorPermutation = null
+
+        val embedded = embedProfile(processed, mergedInfo, workspaceDir)
+        return PreparedModelArtifacts(
+            rawFile = sourceFile,
+            origInfo = origInfo,
+            sourceConfig = sourceConfig,
+            processedFile = processed,
+            processedInfo = processedInfo,
+            mergedInfo = mergedInfo,
+            embeddedFile = embedded
+        )
     }
 
     /**


### PR DESCRIPTION
## Summary
- introduce a shared `prepareImportedModelArtifacts(...)` helper in `SlicerViewModel`
- route the duplicated imported-3MF preparation flow used by `loadModel(uri)`, `loadModelFromFile(file)`, and MakerWorld/shared-url import through that one helper
- keep the stage contract explicit: original parse/config capture, sanitize/deferred restructure, merged 3MF metadata, and embedded output artifact
- preserve the existing multi-plate selector flow instead of starting the larger desktop/shared-core refactor

## Tests
- added `PreparePreviewViewModelTest#dragonScale_importViaUri_matchesDirectFilePipelineArtifacts`
- `./gradlew testDebugUnitTest --no-daemon`
- `./gradlew connectedDebugAndroidTest --no-daemon`
- manual E2E full 16-file batch on Pixel 8a: 16/16 PASS

## Review Notes
- this is the smallest safe refactor boundary for stage 0.5: consolidate duplicated import-preparation logic without changing downstream plate selection / slicing responsibilities
- during E2E verification, `old.3mf=1163 layers` and `tetrahedron.stl=49 layers` matched current observed device behavior; older historical notes claiming `634` / `47` appear stale rather than regressions

## Out Of Scope
- no Android export UI work
- no desktop/shared-core extraction yet
- no regression corpus removal; tests build on the existing coverage
