### PR TITLE
merge: F73/F74/camera fixes plus Bambu artifact export

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,6 +4,12 @@ Open bugs, features, and investigations. Everything else is done — see git log
 
 ## Open Bugs
 
+### B87: Black layers in Prepare preview missing from G-code preview after slicing (GitHub #88)
+- **Symptom**: Skywing Seawing Hybrid Dragon 3MF — bottom layers shown as black in Prepare screen do not appear black in the G-code preview after slicing. The actual print matches the incorrect G-code preview (no black on bottom layers). Reproducible at both 70% and 100% scale; eye components show correct colours.
+- **Root cause**: TBD — confirmed file-specific.
+- **Source**: Discord user DC15, 2026-04-20
+- **Test file**: `天翼，海翼，丝翼拆件多色.3mf` (test-data folder on G-Drive); MakerWorld model 2661371
+
 ### B86: S-Buttons Prepare preview shows 3 colours instead of 4 — FIXED v1.6.1 (GitHub #85)
 - **Symptom**: `Button-for-S-trousers.3mf` Prepare preview intermittently showed yellow, white, blue but not pink (E4). G-code preview after slicing showed all 4 correctly.
 - **Root cause**: DataStore race in `SlicerViewModel.loadNativeModel`. `extruderPresets.value` read the StateFlow's initial placeholder (`defaultExtruderPresets()` = red/green/blue/white) before DataStore had emitted the actual stored user presets. `findClosestExtruder` then mapped S-Buttons detected colours against the defaults, producing a non-identity `colorMapping`. Later `refreshMappedPreviewColors` updated `activeExtruderColors` to the correct user colours but never updated `colorMapping`, so the Compose palette `colorMapping.map { slot → extruderColors[slot] }` incorrectly assigned E4 objects (slot 3) to `extruderColors[colorMapping[3]]` which pointed at white (E2's slot).
@@ -90,19 +96,19 @@ Open bugs, features, and investigations. Everything else is done — see git log
 - **Fix**: (1) `sapil_arrange.cpp` — use `trafo.get_scaling_factor()` to multiply meshBB.min before offset computation. (2) `MainActivity.kt` — add `lib.setModelScale(1f, 1f, 1f)` before `getPreparePreviewMesh()` in the Prepare preview LaunchedEffect (alongside the existing B72 instance reset).
 - **Tests**: `SlicingIntegrationTest.threeMf_scaledDown50pct_gcodeIsCenteredOnBed`, `SlicingIntegrationTest.setModelInstances_withScale_placesInstanceAtCorrectOffset`
 
-### B72: Prepare preview corrupted (shattered mesh) after scale + copies + slice (GitHub #78)
+### B72: Prepare preview corrupted (shattered mesh) after scale + copies + slice (GitHub #78) — FIXED v1.5.70
 - After increasing model scale, increasing copy count, slicing, then returning to Prepare tab, the preview mesh looks geometrically shattered. The slice output is correct.
 - **Root cause**: `setModelInstances()` is called during `prepareSlicer()` with N grid positions. The scale change clears the prepare-preview cache but the cache is never repopulated (LaunchedEffect key=modelRotation doesn't change). On tab return the composable is recreated with a null cache, triggering a fresh `getPreparePreviewMesh()` on the post-slice native state which has N instances set — returning all N copies baked in world-space. The GL renderer then also applies instancePositions for N copies → N×N corruption.
 - **Fix**: Reset to single centred instance (`setModelInstances(floatArrayOf(135f, 135f))`) before calling `getPreparePreviewMesh()` in the Prepare preview LaunchedEffect.
 - **Test**: `NativePreparePreviewTest.getPreparePreviewMesh_afterMultiInstanceSliceState_singleInstanceResetGivesCorrectBounds`
 
-### B68: Printer offline notification shown during printing — misleading text (GitHub #75)
+### B68: Printer offline notification shown during printing — misleading text (GitHub #75) — FIXED v1.5.67
 - While a print is actively in progress, the app shows a "printer offline" notification
 - May be unavoidable (Android limits background WebSocket connections), but text is misleading — implies the printer went offline rather than that the app lost its monitoring connection
 - **Suggested fix**: Change notification text to "Press to connect to see printer status" (or similar)
 - **Source**: Discord user Jon (2026-04-14)
 
-### B67: Import configuration only partially connects printer — camera doesn't show (GitHub #74)
+### B67: Import configuration only partially connects printer — camera doesn't show (GitHub #74) — FIXED v1.5.67
 - After importing a printer configuration (QR code / settings import), printer appears connected but live camera feed does not load
 - User must navigate to Printer Settings and tap Connect manually to fully connect
 - **Expected**: Import should result in a fully connected printer (camera + status working)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Public vulnerability reports should follow [`SECURITY.md`](SECURITY.md). Keep an
 ## Test
 
 ```bash
-./gradlew testDebugUnitTest                        # 819 JVM unit tests
+./gradlew testDebugUnitTest                        # 821 JVM unit tests
 ./gradlew connectedDebugAndroidTest                # 186 instrumented tests (uses Orchestrator)
 ```
 
@@ -70,7 +70,7 @@ For local device IDs and any private E2E notes, consult `E2E_TESTING.local.md` i
 - `viewer/MeshDataTest.kt` (11) — MeshData 10-float vertex format, extruderIndices, recolor(), RGBA values, multi-extruder recolor
 - `viewer/ThreeMfMeshParserTest.kt` (29) - 3MF mesh parsing, per-triangle color extraction, extruderMap, MeshWithContext, SEMM paint_color parsing, multi-object extruder map
 - `network/MakerWorldUtilsTest.kt` (36) — URL parsing, design→instance ID resolution, download response parsing, error classification, cookie sanitization
-- `network/MoonrakerClientTest.kt` (36) — PrinterStatus computed properties, URL normalization, LED state, remoteScreenUrl(), B33 virtual_sdcard progress parsing, sendGcode network path
+- `network/MoonrakerClientTest.kt` (38) — PrinterStatus computed properties, URL normalization, LED state, remoteScreenUrl(), B33 virtual_sdcard progress parsing, sendGcode network path, queryWebcamSnapshotCandidates monitor.jpg appending
 - `data/SliceConfigTest.kt` (25) — Default values match Snapmaker U1 hardware specs, wipe tower bounds clamping
 - `data/DataClassesTest.kt` (17) — FilamentProfile, SliceJob, GcodeMove, ModelInfo, WipeTowerInfo
 - `data/PlateTypeTest.kt` (21) — PlateType.bedTempFor per-material presets, fromName, case-insensitivity

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 Android app wrapping **Snapmaker Orca 2.2.4** (OrcaSlicer fork) for Snapmaker U1 (270×270×270mm, 4 extruders).
 Kotlin + Jetpack Compose + Material3 blue theme + Native C++ via JNI.
 App ID: `com.u1.slicer.orca`
-Current release: `v1.6.1` (`versionCode 245`)
+Current release: `v1.6.3` (`versionCode 247`)
 
 > For local-only device IDs, adb targets, and any machine-specific workflow notes, see `CLAUDE.local.md` if present.
 > For the current deep-dive on the post-upgrade native Clipper failure, see [`CLIPPER_UPGRADE_INVESTIGATION.md`](CLIPPER_UPGRADE_INVESTIGATION.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Public vulnerability reports should follow [`SECURITY.md`](SECURITY.md). Keep an
 ## Test
 
 ```bash
-./gradlew testDebugUnitTest                        # 821 JVM unit tests
+./gradlew testDebugUnitTest                        # 827 JVM unit tests
 ./gradlew connectedDebugAndroidTest                # 186 instrumented tests (uses Orchestrator)
 ```
 
@@ -61,7 +61,7 @@ For local device IDs and any private E2E notes, consult `E2E_TESTING.local.md` i
 
 > **NEVER weaken a test assertion to make a failing test pass.** Do not change `>= 4` to `>= 2`, rename tests to match reduced expectations, or adjust expected values downward. Tests document correct behaviour. A failing test means the code regressed — investigate the root cause and fix the code, not the test.
 
-### Unit tests (`app/src/test/`) - 807 tests across 55 classes
+### Unit tests (`app/src/test/`) - 813 tests across 56 classes
 - `gcode/GcodeParserTest.kt` (33) — G-code parsing: layers, extrusion, extruder switching, ;TYPE: feature-type tagging, wipeTowerFilamentMm, B52 maxMoves cap + stride distribution
 - `gcode/GcodeValidatorTest.kt` (45) — Tool changes, nozzle temps, layer count, prime tower footprint, bed bounds validation
 - `gcode/SuspiciousLineContextTest.kt` (6) — B52 streaming line context lookup: window clamping, multi-sample cap, large file smoke test
@@ -91,6 +91,7 @@ For local device IDs and any private E2E notes, consult `E2E_TESTING.local.md` i
 - `MergeThreeMfInfoTest.kt` (49) — mergeThreeMfInfo/ForPlate objectExtruderMap preference, preview file selection, H2C source detection, SEMM extruderRemap suppression, isHueforgePlate classification (extruder diversity, plate-level paint data, uniform extruder, mixed-paint plates), B60 hasPaintSupports preservation, B82 per-plate layer-tool secondary colour matching (palette-match = real, off-palette = artefact)
 - `printer/PrinterRepositoryTest.kt` (2) — upload filename sanitization and unique suffix generation
 - `printer/PrinterRepositoryNotificationTest.kt` (9) — printer state transition detection for all event types
+- `printer/PrinterViewModelTest.kt` (4) — camera keepalive idempotency helper and LED-sync connection-edge helper
 - `AppEventNotifierTest.kt` (13) — notification title/body/channel/navigate-target for all event types
 - `PreviewSummaryMappingTest.kt` (7) — preview summary data class mapping, F65 resolveExtruderMaterialType by slot, F68 single-colour material label
 - `PreviewColorNormalizationTest.kt` (7) — preview colour normalization
@@ -134,7 +135,7 @@ For local device IDs and any private E2E notes, consult `E2E_TESTING.local.md` i
 - `gcode/GcodeThumbnailInjectorTest.kt` (8) — 3MF image extraction, thumbnail blocks, G-code injection
 - `viewer/NativePreparePreviewTest.kt` (16) — native Prepare preview regressions: dual-colour, painted, old asset, selected multi-plate spread, Dragon plate 3 colour preservation, H2C benchy full/decimated 7-index preservation + green recolor + interleaving guard, layer-tool Z-band recolor, triangle count cap, B51 old.3mf bounding box + Korok orientation, B72 multi-instance post-slice bounds, B78 Shashibo plate 5 file-scale+centre preservation on fresh load + post-slice dirty-path reset
 - `viewer/ThreeMfMeshParserTest.kt` (4) - 3MF mesh parsing, transform resolution, per-triangle color extraction, calicube extruder indices
-- `PreparePreviewViewModelTest.kt` (8) — Dragon plate 3 end-to-end Prepare state, slice-output colour coverage, H2C benchy full pipeline green verification, B47 colorMapping-before-ModelLoaded ordering contract, B83 plate-switch objectIds stable-source fix, entry-point equivalence for `loadModel(uri)` vs `loadModelFromFile(file)`, B86 S-Buttons user-like presets (E2=white/E4=pink) 4-distinct-colour guard
+- `PreparePreviewViewModelTest.kt` (10) — Dragon plate 3 end-to-end Prepare state, slice-output colour coverage, H2C benchy full pipeline green verification, B47 colorMapping-before-ModelLoaded ordering contract, B83 plate-switch objectIds stable-source fix, entry-point equivalence for `loadModel(uri)` vs `loadModelFromFile(file)`, B86 S-Buttons user-like presets (E2=white/E4=pink) 4-distinct-colour guard
 - `ui/MakerWorldBrowserUtilsInstrumentedTest.kt` (6) — resolveDownloadFilename with URLUtil, RFC 5987, path traversal sanitization
 
 ### Red-green TDD for bug fixes

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "com.u1.slicer.orca"
         minSdk 26
         targetSdk 34
-        versionCode 247
-        versionName "1.6.3"
+        versionCode 248
+        versionName "1.6.4"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "com.u1.slicer.orca"
         minSdk 26
         targetSdk 34
-        versionCode 249
-        versionName "1.6.5"
+        versionCode 250
+        versionName "1.6.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "com.u1.slicer.orca"
         minSdk 26
         targetSdk 34
-        versionCode 246
-        versionName "1.6.2"
+        versionCode 247
+        versionName "1.6.3"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "com.u1.slicer.orca"
         minSdk 26
         targetSdk 34
-        versionCode 248
-        versionName "1.6.4"
+        versionCode 249
+        versionName "1.6.5"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,8 +12,8 @@ android {
         applicationId "com.u1.slicer.orca"
         minSdk 26
         targetSdk 34
-        versionCode 250
-        versionName "1.6.6"
+        versionCode 251
+        versionName "1.6.7"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/androidTest/java/com/u1/slicer/PreparePreviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/u1/slicer/PreparePreviewViewModelTest.kt
@@ -765,6 +765,90 @@ class PreparePreviewViewModelTest {
         }
     }
 
+    /**
+     * F73: After loading a multi-plate 3MF and selecting an initial plate, tapping "Change plate"
+     * and selecting a different plate must invalidate the Prepare preview cache so that
+     * InlineModelPreview re-fetches the new plate's native mesh.
+     *
+     * Bug: loadNativeModel() never called invalidatePrepareMeshCache(), so cachedPrepareMesh
+     * held the previous plate's mesh. InlineModelPreview's LaunchedEffect(modelRotation) has
+     * an early-return guard "if (mesh != null && cachedMesh != null) return" — with the stale
+     * cache, this guard fired and skipped getPreparePreviewMesh(), leaving viewerLoading=true
+     * (spinner) indefinitely.
+     *
+     * Red: cachedPrepareMesh is non-null after plate re-selection (bug present).
+     * Green: cachedPrepareMesh is null after plate re-selection (bug fixed).
+     */
+    @Test
+    fun f73_changePlate_multiPlatePlatesAvailableAndCacheInvalidated() {
+        val application = targetContext.applicationContext as U1SlicerApplication
+        val viewModel = SlicerViewModel(application)
+        val modelFile = copyAssetToCache("Dragon Scale infinity.3mf")
+
+        try {
+            viewModel.loadModelFromFile(modelFile)
+
+            waitUntil("plate selector visible") { viewModel.showPlateSelector.value }
+
+            // multiPlatePlates must be populated before initial selection
+            assertTrue(
+                "F73: multiPlatePlates must be non-empty after multi-plate load",
+                viewModel.multiPlatePlates.value.isNotEmpty()
+            )
+
+            // Select initial plate
+            viewModel.selectPlate(1)
+            val plate1Info = viewModel.threeMfInfo.value
+            waitUntil("plate 1 loaded", timeoutMs = 90_000L) {
+                viewModel.state.value is SlicerViewModel.SlicerState.ModelLoaded
+            }
+
+            // multiPlatePlates must survive selectPlate() — this keeps the chip visible
+            assertTrue(
+                "F73: multiPlatePlates must survive selectPlate() so the Change plate chip stays visible",
+                viewModel.multiPlatePlates.value.isNotEmpty()
+            )
+
+            // Simulate InlineModelPreview caching the preview mesh after it loads
+            val plate1Mesh = NativeLibrary().getPreparePreviewMesh()?.toMeshData()
+            assertNotNull("Plate 1 preview mesh should be available for cache simulation", plate1Mesh)
+            viewModel.cachedPrepareMesh = plate1Mesh
+
+            // reopenPlateSelector must open the dialog
+            viewModel.reopenPlateSelector()
+            assertTrue(
+                "F73: reopenPlateSelector() must set showPlateSelector=true when plates available",
+                viewModel.showPlateSelector.value
+            )
+
+            // Select a different plate (simulates user picking from the reopened dialog)
+            viewModel.selectPlate(3)
+            waitUntil("plate 3 info loaded (threeMfInfo replaced)", timeoutMs = 90_000L) {
+                viewModel.state.value is SlicerViewModel.SlicerState.ModelLoaded &&
+                    viewModel.threeMfInfo.value !== plate1Info
+            }
+
+            // Core assertion: cachedPrepareMesh must be null after plate re-selection.
+            // If it is non-null, InlineModelPreview's LaunchedEffect(modelRotation, modelFilePath)
+            // hits the B49 early-return guard and never calls getPreparePreviewMesh() for the
+            // new plate — the spinner shows indefinitely (F73 regression).
+            assertNull(
+                "F73: cachedPrepareMesh must be null after plate re-selection so InlineModelPreview " +
+                    "re-fetches the new plate's preview mesh (stale cache causes spinner-forever bug)",
+                viewModel.cachedPrepareMesh
+            )
+
+            // multiPlatePlates must still be non-empty — user can change plate again
+            assertTrue(
+                "F73: multiPlatePlates must survive second selectPlate() for subsequent changes",
+                viewModel.multiPlatePlates.value.isNotEmpty()
+            )
+        } finally {
+            viewModel.clearModel()
+            modelFile.delete()
+        }
+    }
+
     private fun waitUntil(label: String, timeoutMs: Long = 30_000L, condition: () -> Boolean) {
         val deadline = System.currentTimeMillis() + timeoutMs
         while (System.currentTimeMillis() < deadline) {

--- a/app/src/androidTest/java/com/u1/slicer/PreparePreviewViewModelTest.kt
+++ b/app/src/androidTest/java/com/u1/slicer/PreparePreviewViewModelTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/app/src/main/java/com/u1/slicer/MainActivity.kt
+++ b/app/src/main/java/com/u1/slicer/MainActivity.kt
@@ -40,6 +40,9 @@ import kotlin.math.roundToInt
 import androidx.navigation.compose.rememberNavController
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.core.content.pm.PackageInfoCompat
 import com.u1.slicer.data.ModelInfo
 import com.u1.slicer.data.SliceResult
@@ -48,6 +51,7 @@ import com.u1.slicer.debug.TestCommandReceiver
 import com.u1.slicer.navigation.U1NavGraph
 import com.u1.slicer.navigation.Routes
 import com.u1.slicer.printer.PrinterViewModel
+import com.u1.slicer.ui.InspectModelSheet
 import com.u1.slicer.ui.JobsScreen
 import com.u1.slicer.ui.PrinterScreen
 import com.u1.slicer.ui.SettingsScreen
@@ -63,6 +67,7 @@ class MainActivity : ComponentActivity() {
     private var launchApkUpdateTime: Long = 0L
     private var pendingNavigateTo: String? = null
     private var navigateTabCallback: ((String) -> Unit)? = null
+    private var pendingArtifactExportKind: ExportArtifactKind? = null
 
     private val filePickerLauncher = registerForActivityResult(
         ActivityResultContracts.OpenDocument()
@@ -82,6 +87,52 @@ class MainActivity : ComponentActivity() {
         ActivityResultContracts.CreateDocument("application/octet-stream")
     ) { uri ->
         uri?.let { viewModel.saveGcodeTo(it) }
+    }
+
+    private val sanitizedModelExportLauncher = registerForActivityResult(
+        ActivityResultContracts.CreateDocument("application/vnd.ms-3mfdocument")
+    ) { uri ->
+        val kind = pendingArtifactExportKind
+        pendingArtifactExportKind = null
+        if (uri != null && kind == ExportArtifactKind.Sanitized3mf) {
+            exportModelArtifact(kind, uri)
+        }
+    }
+
+    private val embeddedModelExportLauncher = registerForActivityResult(
+        ActivityResultContracts.CreateDocument("application/vnd.ms-3mfdocument")
+    ) { uri ->
+        val kind = pendingArtifactExportKind
+        pendingArtifactExportKind = null
+        if (uri != null && kind == ExportArtifactKind.SanitizedEmbedded3mf) {
+            exportModelArtifact(kind, uri)
+        }
+    }
+
+    private fun exportModelArtifact(kind: ExportArtifactKind, uri: Uri) {
+        viewModel.exportArtifactTo(kind, uri) { result ->
+            val message = result.fold(
+                onSuccess = {
+                    when (kind) {
+                        ExportArtifactKind.Sanitized3mf -> "Sanitized 3MF exported"
+                        ExportArtifactKind.SanitizedEmbedded3mf -> "Sanitized + embedded 3MF exported"
+                    }
+                },
+                onFailure = { error ->
+                    "Export failed: ${error.message ?: error.javaClass.simpleName}"
+                }
+            )
+            android.widget.Toast.makeText(this, message, android.widget.Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun copyModelDebugSummary() {
+        val summary = viewModel.buildModelDebugSummary() ?: return
+        val clipboard = getSystemService(android.content.ClipboardManager::class.java)
+        clipboard.setPrimaryClip(
+            android.content.ClipData.newPlainText("U1 Slicer Model Debug Summary", summary)
+        )
+        android.widget.Toast.makeText(this, "Debug summary copied", android.widget.Toast.LENGTH_SHORT).show()
     }
 
     override fun onNewIntent(intent: Intent) {
@@ -491,6 +542,19 @@ class MainActivity : ComponentActivity() {
                             onNavigatePrinter = { navigateTab(Routes.PRINTER) },
                             onNavigateJobs = { navigateTab(Routes.JOBS) },
                             onNavigateModelViewer = { navController.navigate(Routes.MODEL_VIEWER) },
+                            onExportSanitized3mf = {
+                                viewModel.suggestedArtifactFilename(ExportArtifactKind.Sanitized3mf)?.let { filename ->
+                                    pendingArtifactExportKind = ExportArtifactKind.Sanitized3mf
+                                    sanitizedModelExportLauncher.launch(filename)
+                                }
+                            },
+                            onExportSanitizedEmbedded3mf = {
+                                viewModel.suggestedArtifactFilename(ExportArtifactKind.SanitizedEmbedded3mf)?.let { filename ->
+                                    pendingArtifactExportKind = ExportArtifactKind.SanitizedEmbedded3mf
+                                    embeddedModelExportLauncher.launch(filename)
+                                }
+                            },
+                            onCopyModelDebugSummary = { copyModelDebugSummary() },
                             sharedPreviewCameraState = sharedPreviewCameraState,
                             onSharedPreviewCameraStateChange = { sharedPreviewCameraState = it },
                             onResetPreviewCamera = { sharedPreviewCameraState = null },
@@ -685,6 +749,9 @@ fun PrepareScreen(
     onNavigatePrinter: () -> Unit,
     onNavigateJobs: () -> Unit,
     onNavigateModelViewer: () -> Unit,
+    onExportSanitized3mf: () -> Unit,
+    onExportSanitizedEmbedded3mf: () -> Unit,
+    onCopyModelDebugSummary: () -> Unit,
     sharedPreviewCameraState: com.u1.slicer.viewer.CameraViewState?,
     onSharedPreviewCameraStateChange: (com.u1.slicer.viewer.CameraViewState) -> Unit,
     onResetPreviewCamera: (() -> Unit)? = null,
@@ -710,7 +777,9 @@ fun PrepareScreen(
     val extruderColors by viewModel.activeExtruderColors.collectAsState()
     val layerToolOnly by viewModel.layerToolOnly.collectAsState()
     val sourceConfig by viewModel.sourceConfig.collectAsState()
+    val exportArtifacts = viewModel.getExportableModelArtifacts()
     var captureViewer by remember { mutableStateOf<com.u1.slicer.viewer.ModelViewerView?>(null) }
+    var showInspectModelSheet by remember { mutableStateOf(false) }
 
     // Plate selector dialog
     if (showPlateSelector && threeMfInfo != null) {
@@ -733,6 +802,24 @@ fun PrepareScreen(
                 viewModel.applyMultiColorAssignments(mapping, extruderPresets, filaments)
             },
             onDismiss = { viewModel.dismissMultiColorDialog() }
+        )
+    }
+
+    if (showInspectModelSheet && exportArtifacts != null) {
+        InspectModelSheet(
+            artifacts = exportArtifacts,
+            onDismiss = { showInspectModelSheet = false },
+            onExportSanitized = {
+                showInspectModelSheet = false
+                onExportSanitized3mf()
+            },
+            onExportEmbedded = {
+                showInspectModelSheet = false
+                onExportSanitizedEmbedded3mf()
+            },
+            onCopyDebugSummary = {
+                onCopyModelDebugSummary()
+            }
         )
     }
 
@@ -761,6 +848,11 @@ fun PrepareScreen(
                     containerColor = MaterialTheme.colorScheme.surface
                 ),
                 actions = {
+                    if (exportArtifacts != null) {
+                        IconButton(onClick = { showInspectModelSheet = true }) {
+                            Icon(Icons.Default.Info, "Inspect model")
+                        }
+                    }
                     if (state !is SlicerViewModel.SlicerState.Idle) {
                         IconButton(onClick = { viewModel.clearModel() }) {
                             Icon(Icons.Default.Clear, "Clear model")
@@ -3007,35 +3099,158 @@ fun ScaleSection(
                             )
                         }
                         Divider(color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
+                        val focusManager = LocalFocusManager.current
                         if (uniformMode) {
-                            val pct = "%.0f%%".format(uniformValue * 100)
-                            Text("Scale: $pct", style = MaterialTheme.typography.labelMedium)
+                            var uniformText by remember(uniformValue) {
+                                mutableStateOf("%.0f".format(uniformValue * 100))
+                            }
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text("Scale", style = MaterialTheme.typography.labelMedium)
+                                OutlinedTextField(
+                                    value = uniformText,
+                                    onValueChange = { uniformText = it },
+                                    suffix = { Text("%") },
+                                    keyboardOptions = KeyboardOptions(
+                                        keyboardType = KeyboardType.Number,
+                                        imeAction = ImeAction.Done
+                                    ),
+                                    keyboardActions = KeyboardActions(onDone = {
+                                        val v = uniformText.toFloatOrNull()
+                                            ?.div(100f)?.coerceIn(0.1f, 3f) ?: uniformValue
+                                        uniformValue = v
+                                        uniformText = "%.0f".format(v * 100)
+                                        onScaleChange(SlicerViewModel.ModelScale(v, v, v))
+                                        focusManager.clearFocus()
+                                    }),
+                                    singleLine = true,
+                                    modifier = Modifier.width(96.dp)
+                                )
+                            }
                             Slider(
                                 value = uniformValue,
                                 onValueChange = { v ->
                                     uniformValue = v
+                                    uniformText = "%.0f".format(v * 100)
                                     onScaleChange(SlicerViewModel.ModelScale(v, v, v))
                                 },
-                                valueRange = 0.1f..3f,
-                                steps = 28
+                                valueRange = 0.1f..3f
                             )
                         } else {
-                            listOf("X" to scale.x, "Y" to scale.y, "Z" to scale.z).forEach { (axis, v) ->
-                                Text("$axis: ${"%.0f%%".format(v * 100)}", style = MaterialTheme.typography.labelMedium)
-                                Slider(
-                                    value = v,
-                                    onValueChange = { nv ->
-                                        val ns = when (axis) {
-                                            "X" -> scale.copy(x = nv)
-                                            "Y" -> scale.copy(y = nv)
-                                            else -> scale.copy(z = nv)
-                                        }
-                                        onScaleChange(ns)
-                                    },
-                                    valueRange = 0.1f..3f,
-                                    steps = 28
+                            var xText by remember(scale.x) {
+                                mutableStateOf("%.0f".format(scale.x * 100))
+                            }
+                            var yText by remember(scale.y) {
+                                mutableStateOf("%.0f".format(scale.y * 100))
+                            }
+                            var zText by remember(scale.z) {
+                                mutableStateOf("%.0f".format(scale.z * 100))
+                            }
+                            // X
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text("X", style = MaterialTheme.typography.labelMedium)
+                                OutlinedTextField(
+                                    value = xText,
+                                    onValueChange = { xText = it },
+                                    suffix = { Text("%") },
+                                    keyboardOptions = KeyboardOptions(
+                                        keyboardType = KeyboardType.Number,
+                                        imeAction = ImeAction.Done
+                                    ),
+                                    keyboardActions = KeyboardActions(onDone = {
+                                        val v = xText.toFloatOrNull()
+                                            ?.div(100f)?.coerceIn(0.1f, 3f) ?: scale.x
+                                        xText = "%.0f".format(v * 100)
+                                        onScaleChange(scale.copy(x = v))
+                                        focusManager.clearFocus()
+                                    }),
+                                    singleLine = true,
+                                    modifier = Modifier.width(96.dp)
                                 )
                             }
+                            Slider(
+                                value = scale.x,
+                                onValueChange = { nv ->
+                                    xText = "%.0f".format(nv * 100)
+                                    onScaleChange(scale.copy(x = nv))
+                                },
+                                valueRange = 0.1f..3f
+                            )
+                            // Y
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text("Y", style = MaterialTheme.typography.labelMedium)
+                                OutlinedTextField(
+                                    value = yText,
+                                    onValueChange = { yText = it },
+                                    suffix = { Text("%") },
+                                    keyboardOptions = KeyboardOptions(
+                                        keyboardType = KeyboardType.Number,
+                                        imeAction = ImeAction.Done
+                                    ),
+                                    keyboardActions = KeyboardActions(onDone = {
+                                        val v = yText.toFloatOrNull()
+                                            ?.div(100f)?.coerceIn(0.1f, 3f) ?: scale.y
+                                        yText = "%.0f".format(v * 100)
+                                        onScaleChange(scale.copy(y = v))
+                                        focusManager.clearFocus()
+                                    }),
+                                    singleLine = true,
+                                    modifier = Modifier.width(96.dp)
+                                )
+                            }
+                            Slider(
+                                value = scale.y,
+                                onValueChange = { nv ->
+                                    yText = "%.0f".format(nv * 100)
+                                    onScaleChange(scale.copy(y = nv))
+                                },
+                                valueRange = 0.1f..3f
+                            )
+                            // Z
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text("Z", style = MaterialTheme.typography.labelMedium)
+                                OutlinedTextField(
+                                    value = zText,
+                                    onValueChange = { zText = it },
+                                    suffix = { Text("%") },
+                                    keyboardOptions = KeyboardOptions(
+                                        keyboardType = KeyboardType.Number,
+                                        imeAction = ImeAction.Done
+                                    ),
+                                    keyboardActions = KeyboardActions(onDone = {
+                                        val v = zText.toFloatOrNull()
+                                            ?.div(100f)?.coerceIn(0.1f, 3f) ?: scale.z
+                                        zText = "%.0f".format(v * 100)
+                                        onScaleChange(scale.copy(z = v))
+                                        focusManager.clearFocus()
+                                    }),
+                                    singleLine = true,
+                                    modifier = Modifier.width(96.dp)
+                                )
+                            }
+                            Slider(
+                                value = scale.z,
+                                onValueChange = { nv ->
+                                    zText = "%.0f".format(nv * 100)
+                                    onScaleChange(scale.copy(z = nv))
+                                },
+                                valueRange = 0.1f..3f
+                            )
                         }
                         if (scale.x != 1f || scale.y != 1f || scale.z != 1f) {
                             TextButton(

--- a/app/src/main/java/com/u1/slicer/MainActivity.kt
+++ b/app/src/main/java/com/u1/slicer/MainActivity.kt
@@ -764,6 +764,8 @@ fun PrepareScreen(
     val modelInfo by viewModel.modelInfo.collectAsState()
     val showPlateSelector by viewModel.showPlateSelector.collectAsState()
     val multiPlatePlates by viewModel.multiPlatePlates.collectAsState()
+    val currentModelName by viewModel.modelFileName.collectAsState()
+    val currentPlateId by viewModel.currentPlateId.collectAsState()
     val showMultiColorDialog by viewModel.showMultiColorDialog.collectAsState()
     val colorMapping by viewModel.colorMapping.collectAsState()
     val threeMfInfo by viewModel.threeMfInfo.collectAsState()
@@ -986,19 +988,40 @@ fun PrepareScreen(
                                 )
                             }
                         }
-                        // Change plate chip — visible when a multi-plate file is loaded
-                        if (multiPlatePlates.isNotEmpty()) {
-                            AssistChip(
-                                onClick = { viewModel.reopenPlateSelector() },
-                                label = { Text("Change plate") },
-                                leadingIcon = {
-                                    Icon(
-                                        Icons.Default.Layers,
-                                        contentDescription = null,
-                                        modifier = Modifier.size(16.dp)
+                        // File/plate label row — always shown when a model is loaded
+                        if (currentModelName.isNotEmpty()) {
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                if (multiPlatePlates.isNotEmpty()) {
+                                    AssistChip(
+                                        onClick = { viewModel.reopenPlateSelector() },
+                                        label = { Text("Change plate") },
+                                        leadingIcon = {
+                                            Icon(
+                                                Icons.Default.Layers,
+                                                contentDescription = null,
+                                                modifier = Modifier.size(16.dp)
+                                            )
+                                        }
                                     )
                                 }
-                            )
+                                val displayName = currentModelName
+                                    .removeSuffix(".3mf")
+                                    .removeSuffix(".stl")
+                                    .removeSuffix(".obj")
+                                    .removeSuffix(".step")
+                                val plateLabel = if (currentPlateId > 0) " · Plate $currentPlateId" else ""
+                                Text(
+                                    text = "$displayName$plateLabel",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.55f),
+                                    maxLines = 1,
+                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                                    modifier = Modifier.weight(1f)
+                                )
+                            }
                         }
                         // Inline extruder/color assignment + prime tower toggle
                         PrintSetupSection(

--- a/app/src/main/java/com/u1/slicer/MainActivity.kt
+++ b/app/src/main/java/com/u1/slicer/MainActivity.kt
@@ -2365,7 +2365,7 @@ fun InlineModelPreview(
     // Without debouncing, each intermediate value cancels the previous LaunchedEffect,
     // wasting the 30s computation and restarting.  The initial call (rot=0,0,0) skips
     // the delay so model load isn't slowed.
-    LaunchedEffect(modelRotation) {
+    LaunchedEffect(modelRotation, modelFilePath) {
         val rot = modelRotation
 
         // B49: reuse cached mesh if available (instant reload on tab switch).

--- a/app/src/main/java/com/u1/slicer/MainActivity.kt
+++ b/app/src/main/java/com/u1/slicer/MainActivity.kt
@@ -51,7 +51,6 @@ import com.u1.slicer.debug.TestCommandReceiver
 import com.u1.slicer.navigation.U1NavGraph
 import com.u1.slicer.navigation.Routes
 import com.u1.slicer.printer.PrinterViewModel
-import com.u1.slicer.ui.InspectModelSheet
 import com.u1.slicer.ui.JobsScreen
 import com.u1.slicer.ui.PrinterScreen
 import com.u1.slicer.ui.SettingsScreen
@@ -780,9 +779,7 @@ fun PrepareScreen(
     val extruderColors by viewModel.activeExtruderColors.collectAsState()
     val layerToolOnly by viewModel.layerToolOnly.collectAsState()
     val sourceConfig by viewModel.sourceConfig.collectAsState()
-    val exportArtifacts = viewModel.getExportableModelArtifacts()
     var captureViewer by remember { mutableStateOf<com.u1.slicer.viewer.ModelViewerView?>(null) }
-    var showInspectModelSheet by remember { mutableStateOf(false) }
 
     // Plate selector dialog
     if (showPlateSelector && multiPlatePlates.isNotEmpty()) {
@@ -805,24 +802,6 @@ fun PrepareScreen(
                 viewModel.applyMultiColorAssignments(mapping, extruderPresets, filaments)
             },
             onDismiss = { viewModel.dismissMultiColorDialog() }
-        )
-    }
-
-    if (showInspectModelSheet && exportArtifacts != null) {
-        InspectModelSheet(
-            artifacts = exportArtifacts,
-            onDismiss = { showInspectModelSheet = false },
-            onExportSanitized = {
-                showInspectModelSheet = false
-                onExportSanitized3mf()
-            },
-            onExportEmbedded = {
-                showInspectModelSheet = false
-                onExportSanitizedEmbedded3mf()
-            },
-            onCopyDebugSummary = {
-                onCopyModelDebugSummary()
-            }
         )
     }
 
@@ -851,11 +830,6 @@ fun PrepareScreen(
                     containerColor = MaterialTheme.colorScheme.surface
                 ),
                 actions = {
-                    if (exportArtifacts != null) {
-                        IconButton(onClick = { showInspectModelSheet = true }) {
-                            Icon(Icons.Default.Info, "Inspect model")
-                        }
-                    }
                     if (state !is SlicerViewModel.SlicerState.Idle) {
                         IconButton(onClick = { viewModel.clearModel() }) {
                             Icon(Icons.Default.Clear, "Clear model")
@@ -981,9 +955,13 @@ fun PrepareScreen(
                                 ModelInfoDialog(
                                     info = loadedInfo,
                                     threeMfInfo = threeMfInfo,
+                                    exportArtifacts = viewModel.getExportableModelArtifacts(),
                                     config = config,
                                     onToggleWipeTower = { viewModel.togglePrimeTower() },
                                     onReassign = { viewModel.showMultiColorReassign() },
+                                    onExportSanitized = onExportSanitized3mf,
+                                    onExportEmbedded = onExportSanitizedEmbedded3mf,
+                                    onCopyDebugSummary = onCopyModelDebugSummary,
                                     onDismiss = { showInfoDialog = false }
                                 )
                             }
@@ -2812,9 +2790,13 @@ private fun LargePreviewFallback(
 fun ModelInfoDialog(
     info: ModelInfo,
     threeMfInfo: com.u1.slicer.bambu.ThreeMfInfo?,
+    exportArtifacts: ExportableModelArtifacts?,
     config: com.u1.slicer.data.SliceConfig,
     onToggleWipeTower: () -> Unit,
     onReassign: () -> Unit,
+    onExportSanitized: () -> Unit,
+    onExportEmbedded: () -> Unit,
+    onCopyDebugSummary: () -> Unit,
     onDismiss: () -> Unit
 ) {
     AlertDialog(
@@ -2849,6 +2831,49 @@ fun ModelInfoDialog(
                         InfoRow("Paint Data", "Yes (per-triangle)")
                     if (threeMfInfo.isMultiPlate)
                         InfoRow("Plates", threeMfInfo.plates.size.toString())
+                }
+
+                if (exportArtifacts != null) {
+                    Divider(modifier = Modifier.padding(vertical = 4.dp),
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
+                    Text(
+                        "Export Pipeline Artifacts",
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary,
+                        style = MaterialTheme.typography.labelMedium
+                    )
+                    InfoRow("Selected Plate", exportArtifacts.selectedPlateId?.toString() ?: "None")
+                    InfoRow(
+                        "Sanitized for Orca",
+                        exportArtifacts.fileFor(ExportArtifactKind.Sanitized3mf)?.name ?: "Unavailable"
+                    )
+                    InfoRow(
+                        "Sanitized + U1 profile",
+                        exportArtifacts.fileFor(ExportArtifactKind.SanitizedEmbedded3mf)?.name ?: "Unavailable"
+                    )
+                    OutlinedButton(
+                        onClick = onExportSanitized,
+                        enabled = exportArtifacts.fileFor(ExportArtifactKind.Sanitized3mf) != null,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(8.dp)
+                    ) {
+                        Text("Export Sanitized for Orca Compatibility")
+                    }
+                    OutlinedButton(
+                        onClick = onExportEmbedded,
+                        enabled = exportArtifacts.fileFor(ExportArtifactKind.SanitizedEmbedded3mf) != null,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(8.dp)
+                    ) {
+                        Text("Export Sanitized + U1 Profile Embedded")
+                    }
+                    OutlinedButton(
+                        onClick = onCopyDebugSummary,
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(8.dp)
+                    ) {
+                        Text("Copy Debug Summary")
+                    }
                 }
 
                 if (config.extruderCount > 1) {

--- a/app/src/main/java/com/u1/slicer/MainActivity.kt
+++ b/app/src/main/java/com/u1/slicer/MainActivity.kt
@@ -763,6 +763,7 @@ fun PrepareScreen(
     val context = LocalContext.current
     val modelInfo by viewModel.modelInfo.collectAsState()
     val showPlateSelector by viewModel.showPlateSelector.collectAsState()
+    val multiPlatePlates by viewModel.multiPlatePlates.collectAsState()
     val showMultiColorDialog by viewModel.showMultiColorDialog.collectAsState()
     val colorMapping by viewModel.colorMapping.collectAsState()
     val threeMfInfo by viewModel.threeMfInfo.collectAsState()
@@ -782,9 +783,9 @@ fun PrepareScreen(
     var showInspectModelSheet by remember { mutableStateOf(false) }
 
     // Plate selector dialog
-    if (showPlateSelector && threeMfInfo != null) {
+    if (showPlateSelector && multiPlatePlates.isNotEmpty()) {
         com.u1.slicer.ui.PlateSelectDialog(
-            plates = threeMfInfo!!.plates,
+            plates = multiPlatePlates,
             onSelect = { viewModel.selectPlate(it) },
             onDismiss = { viewModel.dismissPlateSelector() },
             info = threeMfInfo
@@ -984,6 +985,20 @@ fun PrepareScreen(
                                     onDismiss = { showInfoDialog = false }
                                 )
                             }
+                        }
+                        // Change plate chip — visible when a multi-plate file is loaded
+                        if (multiPlatePlates.isNotEmpty()) {
+                            AssistChip(
+                                onClick = { viewModel.reopenPlateSelector() },
+                                label = { Text("Change plate") },
+                                leadingIcon = {
+                                    Icon(
+                                        Icons.Default.Layers,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(16.dp)
+                                    )
+                                }
+                            )
                         }
                         // Inline extruder/color assignment + prime tower toggle
                         PrintSetupSection(

--- a/app/src/main/java/com/u1/slicer/MainActivity.kt
+++ b/app/src/main/java/com/u1/slicer/MainActivity.kt
@@ -970,8 +970,8 @@ fun PrepareScreen(
                                 onResetView = { captureViewer?.resetView(); onResetPreviewCamera?.invoke() },
                                 layerToolOnly = layerToolOnly,
                                 layerToolSegments = threeMfInfo?.layerToolSegments,
-                                cachedMesh = viewModel.cachedPrepareMesh,
-                                onMeshCached = { viewModel.cachedPrepareMesh = it },
+                                cachedMesh = if (viewModel.cachedPrepareMeshPath == modelPath) viewModel.cachedPrepareMesh else null,
+                                onMeshCached = { viewModel.cachedPrepareMeshPath = modelPath; viewModel.cachedPrepareMesh = it },
                                 loadTimeInstanceOffsets = loadTimeInstanceOffsets,
                                 nativeSliceStateDirty = nativeSliceStateDirty
                             )
@@ -2262,8 +2262,15 @@ fun InlineModelPreview(
         // rotation path handles the preview (3MF files).  The parse effect returns
         // null for 3MF — clearing the mesh here just kills the cached preview and
         // forces a slow re-fetch from native.
+        // F73 fix: also don't clear mesh when we already have a displayed mesh (mesh != null)
+        // and the native path is in use.  colorMapping?.size is a LaunchedEffect key so this
+        // effect re-fires on every color-mapping change (e.g. after a plate switch completes
+        // and loadNativeModel emits colorMapping size change).  Without this guard, the effect
+        // clears mesh/viewerLoading that were already correctly set by the rotation effect,
+        // leaving the "Preparing preview…" spinner forever because the rotation effect won't
+        // re-fire (modelFilePath and modelRotation are both unchanged).
         val isNativePreviewPath = modelFilePath.endsWith(".3mf", ignoreCase = true)
-        if (cachedMesh == null || !isNativePreviewPath) {
+        if ((cachedMesh == null && mesh == null) || !isNativePreviewPath) {
             viewerLoading = true
             mesh = null
             lastSetMesh = null

--- a/app/src/main/java/com/u1/slicer/MainActivity.kt
+++ b/app/src/main/java/com/u1/slicer/MainActivity.kt
@@ -66,7 +66,6 @@ class MainActivity : ComponentActivity() {
     private var launchApkUpdateTime: Long = 0L
     private var pendingNavigateTo: String? = null
     private var navigateTabCallback: ((String) -> Unit)? = null
-    private var pendingArtifactExportKind: ExportArtifactKind? = null
 
     private val filePickerLauncher = registerForActivityResult(
         ActivityResultContracts.OpenDocument()
@@ -91,20 +90,16 @@ class MainActivity : ComponentActivity() {
     private val sanitizedModelExportLauncher = registerForActivityResult(
         ActivityResultContracts.CreateDocument("application/vnd.ms-3mfdocument")
     ) { uri ->
-        val kind = pendingArtifactExportKind
-        pendingArtifactExportKind = null
-        if (uri != null && kind == ExportArtifactKind.Sanitized3mf) {
-            exportModelArtifact(kind, uri)
+        if (uri != null) {
+            exportModelArtifact(ExportArtifactKind.Sanitized3mf, uri)
         }
     }
 
     private val embeddedModelExportLauncher = registerForActivityResult(
         ActivityResultContracts.CreateDocument("application/vnd.ms-3mfdocument")
     ) { uri ->
-        val kind = pendingArtifactExportKind
-        pendingArtifactExportKind = null
-        if (uri != null && kind == ExportArtifactKind.SanitizedEmbedded3mf) {
-            exportModelArtifact(kind, uri)
+        if (uri != null) {
+            exportModelArtifact(ExportArtifactKind.SanitizedEmbedded3mf, uri)
         }
     }
 
@@ -543,13 +538,11 @@ class MainActivity : ComponentActivity() {
                             onNavigateModelViewer = { navController.navigate(Routes.MODEL_VIEWER) },
                             onExportSanitized3mf = {
                                 viewModel.suggestedArtifactFilename(ExportArtifactKind.Sanitized3mf)?.let { filename ->
-                                    pendingArtifactExportKind = ExportArtifactKind.Sanitized3mf
                                     sanitizedModelExportLauncher.launch(filename)
                                 }
                             },
                             onExportSanitizedEmbedded3mf = {
                                 viewModel.suggestedArtifactFilename(ExportArtifactKind.SanitizedEmbedded3mf)?.let { filename ->
-                                    pendingArtifactExportKind = ExportArtifactKind.SanitizedEmbedded3mf
                                     embeddedModelExportLauncher.launch(filename)
                                 }
                             },
@@ -2818,7 +2811,7 @@ fun ModelInfoDialog(
                 InfoRow("Manifold", if (info.isManifold) "Yes" else "No")
 
                 if (threeMfInfo != null && threeMfInfo.isBambu) {
-                    Divider(modifier = Modifier.padding(vertical = 4.dp),
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp),
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
                     Text("Bambu Studio File", fontWeight = FontWeight.Bold,
                         color = MaterialTheme.colorScheme.primary,
@@ -2834,7 +2827,7 @@ fun ModelInfoDialog(
                 }
 
                 if (exportArtifacts != null) {
-                    Divider(modifier = Modifier.padding(vertical = 4.dp),
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp),
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
                     Text(
                         "Export Pipeline Artifacts",
@@ -2877,7 +2870,7 @@ fun ModelInfoDialog(
                 }
 
                 if (config.extruderCount > 1) {
-                    Divider(modifier = Modifier.padding(vertical = 4.dp),
+                    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp),
                         color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.1f))
                     Row(
                         modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/u1/slicer/ModelExportArtifacts.kt
+++ b/app/src/main/java/com/u1/slicer/ModelExportArtifacts.kt
@@ -1,0 +1,101 @@
+package com.u1.slicer
+
+import com.u1.slicer.bambu.ThreeMfInfo
+import java.io.File
+import java.util.Locale
+
+enum class ExportArtifactKind {
+    Sanitized3mf,
+    SanitizedEmbedded3mf
+}
+
+data class ExportableModelArtifacts(
+    val sourceDisplayName: String,
+    val selectedPlateId: Int?,
+    val isBambu: Boolean,
+    val sanitizedFile: File?,
+    val embeddedFile: File?,
+    val info: ThreeMfInfo?
+) {
+    fun fileFor(kind: ExportArtifactKind): File? = when (kind) {
+        ExportArtifactKind.Sanitized3mf -> sanitizedFile
+        ExportArtifactKind.SanitizedEmbedded3mf -> embeddedFile
+    }
+}
+
+object ModelExportArtifacts {
+    fun current(
+        sourceDisplayName: String,
+        selectedPlateId: Int?,
+        sanitizedFile: File?,
+        embeddedFile: File?,
+        info: ThreeMfInfo?
+    ): ExportableModelArtifacts? {
+        if (info?.isBambu != true) return null
+        val normalizedSourceName = sourceDisplayName.ifBlank {
+            sanitizedFile?.name ?: embeddedFile?.name ?: "model.3mf"
+        }
+        val exportable = ExportableModelArtifacts(
+            sourceDisplayName = normalizedSourceName,
+            selectedPlateId = selectedPlateId,
+            isBambu = true,
+            sanitizedFile = sanitizedFile?.takeIf(::isExportableThreeMf),
+            embeddedFile = embeddedFile?.takeIf(::isExportableThreeMf),
+            info = info
+        )
+        return exportable.takeIf {
+            it.sanitizedFile != null || it.embeddedFile != null
+        }
+    }
+
+    fun suggestedFilename(
+        sourceDisplayName: String,
+        kind: ExportArtifactKind
+    ): String {
+        val baseName = sourceDisplayName.substringBeforeLast(".", sourceDisplayName)
+            .ifBlank { "model" }
+        return when (kind) {
+            ExportArtifactKind.Sanitized3mf -> "$baseName.sanitized.3mf"
+            ExportArtifactKind.SanitizedEmbedded3mf -> "$baseName.sanitized-embedded.3mf"
+        }
+    }
+
+    fun buildDebugSummary(
+        artifacts: ExportableModelArtifacts,
+        currentWorkingFile: File?
+    ): String {
+        val info = artifacts.info
+        val usedExtruders = info?.usedExtruderIndices
+            ?.sorted()
+            ?.joinToString(", ")
+            ?.ifBlank { "none" }
+            ?: "none"
+        return buildString {
+            appendLine("Source file: ${artifacts.sourceDisplayName}")
+            appendLine("Current working file: ${currentWorkingFile?.name ?: "none"}")
+            appendLine("Bambu file: ${yesNo(artifacts.isBambu)}")
+            appendLine("Multi-plate: ${yesNo(info?.isMultiPlate == true)}")
+            appendLine("Selected plate: ${artifacts.selectedPlateId?.toString() ?: "none"}")
+            appendLine("Detected extruders: ${info?.detectedExtruderCount ?: 0}")
+            appendLine("Paint data: ${yesNo(info?.hasPaintData == true)}")
+            appendLine("Paint supports: ${yesNo(info?.hasPaintSupports == true)}")
+            appendLine("Layer-tool changes: ${yesNo(info?.hasLayerToolChanges == true)}")
+            appendLine("Used extruder indices: $usedExtruders")
+            appendLine("Object-extruder map size: ${info?.objectExtruderMap?.size ?: 0}")
+            appendLine("Sanitized artifact: ${describeArtifact(artifacts.sanitizedFile)}")
+            appendLine("Sanitized + embedded artifact: ${describeArtifact(artifacts.embeddedFile)}")
+        }.trimEnd()
+    }
+
+    private fun yesNo(value: Boolean): String = if (value) "yes" else "no"
+
+    private fun describeArtifact(file: File?): String {
+        if (file == null) return "unavailable"
+        return "${file.name} (${file.absolutePath})"
+    }
+
+    private fun isExportableThreeMf(file: File): Boolean {
+        if (!file.exists() || !file.isFile) return false
+        return file.name.lowercase(Locale.US).endsWith(".3mf")
+    }
+}

--- a/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
@@ -348,7 +348,10 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
 
     // Track the current working file (may be sanitized copy)
     private var currentModelFile: File? = null
+    private val _modelFileName = MutableStateFlow("")
+    val modelFileName: StateFlow<String> = _modelFileName.asStateFlow()
     private var currentModelName: String = ""
+        set(value) { field = value; _modelFileName.value = value }
     private var lastModelInfo: ModelInfo? = null
     private val _modelInfo = MutableStateFlow<ModelInfo?>(null)
     val modelInfo: StateFlow<ModelInfo?> = _modelInfo.asStateFlow()
@@ -375,7 +378,10 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
     // which is why we can't use them in recovery.
     private var rawInputFile: File? = null
     private var recoveryOrigInfo: ThreeMfInfo? = null
+    private val _currentPlateId = MutableStateFlow(-1)
+    val currentPlateId: StateFlow<Int> = _currentPlateId.asStateFlow()
     private var recoveryPlateId: Int = -1
+        set(value) { field = value; _currentPlateId.value = value }
 
     // B24 RC2: Track whether profile needs re-embedding before next slice.
     // Set to true when config/overrides are saved while a model is loaded.

--- a/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
@@ -1112,6 +1112,10 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
 
     private suspend fun loadNativeModel(file: File) {
         val firstModelLoadThisLaunch = diagnostics.markFirstModelLoad()
+        // Stale cached mesh from a previous model/plate load would cause InlineModelPreview's
+        // LaunchedEffect(modelRotation, modelFilePath) to hit the B49 early-return guard and
+        // skip getPreparePreviewMesh() for the new model, leaving the spinner indefinitely.
+        invalidatePrepareMeshCache()
         // Acquire previewMutex before touching native model — prevents SIGSEGV when
         // getPreparePreviewMesh (on the preview coroutine) is iterating model volumes
         // while we clear+reload here.  Large model QEM decimation can hold the lock for

--- a/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
@@ -2260,6 +2260,7 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
                 diagnostics.markSliceInProgress(currentModelFile!!.name)
 
                 val result = native.slice(sliceConfig)
+                ensureActive()
 
                 // Native cancel: slice() returned with cancelled=true from CanceledException
                 if (result?.cancelled == true) {

--- a/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
@@ -301,10 +301,14 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
     // The native side caches the raw mesh, but toMeshData() (normal computation + FloatBuffer
     // allocation) is expensive for large SEMM models (2M tris).  This cache avoids re-conversion.
     // Invalidated on model load, rotation change, or arrangement change.
+    // cachedPrepareMeshPath ties the cache to a specific model file so that a plate switch
+    // (which changes previewModelPath before invalidation runs) doesn't serve a stale mesh.
     @Volatile var cachedPrepareMesh: com.u1.slicer.viewer.MeshData? = null
+    @Volatile var cachedPrepareMeshPath: String? = null
 
     fun invalidatePrepareMeshCache() {
         cachedPrepareMesh = null
+        cachedPrepareMeshPath = null
     }
 
     // Filament library — StateFlow so .value is accessible synchronously (e.g. for nozzle temp lookup at slice time)

--- a/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
@@ -2008,9 +2008,16 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
                 SlicingService.start(context)
                 var maxPct = 0
                 native.progressListener = { pct, stage ->
-                    if (pct > maxPct) maxPct = pct
-                    _state.value = SlicerState.Slicing(maxPct, stage)
-                    SlicingService.updateProgress(context, maxPct, stage)
+                    // Guard: don't override Loading — selectPlate() may have set it to initiate
+                    // a plate switch while this slice was still running. Overriding Loading would
+                    // remount InlineModelPreview against the stale native state and produce
+                    // wrong preview colours on the new plate.
+                    val cur = _state.value
+                    if (cur !is SlicerState.Loading && cur !is SlicerState.Idle) {
+                        if (pct > maxPct) maxPct = pct
+                        _state.value = SlicerState.Slicing(maxPct, stage)
+                        SlicingService.updateProgress(context, maxPct, stage)
+                    }
                 }
 
                 _state.value = SlicerState.Slicing(0, "Preparing...")

--- a/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
@@ -14,6 +14,7 @@ import com.u1.slicer.bambu.BambuSanitizer
 import com.u1.slicer.bambu.ProfileEmbedder
 import com.u1.slicer.bambu.ThreeMfInfo
 import com.u1.slicer.bambu.ThreeMfParser
+import com.u1.slicer.bambu.ThreeMfPlate
 import com.u1.slicer.data.ExtruderPreset
 import com.u1.slicer.data.FilamentProfile
 import com.u1.slicer.data.ModelInfo
@@ -46,6 +47,7 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 import java.security.MessageDigest
 import java.util.zip.ZipFile
@@ -194,6 +196,9 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
     // always see the correct file-level metadata (e.g. hasPaintData=true for files where only
     // some plates have paint data).
     private var _fileThreeMfInfo: ThreeMfInfo? = null
+
+    private val _multiPlatePlates = MutableStateFlow<List<ThreeMfPlate>>(emptyList())
+    val multiPlatePlates: StateFlow<List<ThreeMfPlate>> = _multiPlatePlates.asStateFlow()
 
     private val _showPlateSelector = MutableStateFlow(false)
     val showPlateSelector: StateFlow<Boolean> = _showPlateSelector.asStateFlow()
@@ -1098,6 +1103,11 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
         _multiPlateSourceFile = null
         _threeMfInfo.value = null
         _fileThreeMfInfo = null
+        _multiPlatePlates.value = emptyList()
+    }
+
+    fun reopenPlateSelector() {
+        if (_multiPlatePlates.value.isNotEmpty()) _showPlateSelector.value = true
     }
 
     private suspend fun loadNativeModel(file: File) {
@@ -1579,6 +1589,7 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
 
         _threeMfInfo.value = mergedInfo
         _fileThreeMfInfo = mergedInfo
+        _multiPlatePlates.value = if (origInfo.isMultiPlate) mergedInfo.plates else emptyList()
         sourceModelFile = processed
         sourceModelInfo = processedInfo
         if (origInfo.isMultiPlate) _multiPlateSourceFile = processed
@@ -2949,6 +2960,7 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
         _selectedExtruder.value = 0
         _threeMfInfo.value = null
         _fileThreeMfInfo = null
+        _multiPlatePlates.value = emptyList()
         _multiPlateSourceFile = null
         _showPlateSelector.value = false
         _showMultiColorDialog.value = false
@@ -3046,6 +3058,66 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
                 }
             } catch (_: Throwable) {
                 // Silent fail — user may have cancelled the save dialog
+            }
+        }
+    }
+
+    fun getExportableModelArtifacts(): ExportableModelArtifacts? =
+        ModelExportArtifacts.current(
+            sourceDisplayName = currentModelName,
+            selectedPlateId = recoveryPlateId.takeIf { it >= 0 },
+            sanitizedFile = sourceModelFile,
+            embeddedFile = currentModelFile,
+            info = _threeMfInfo.value
+        )
+
+    fun buildModelDebugSummary(): String? {
+        val artifacts = getExportableModelArtifacts() ?: return null
+        return ModelExportArtifacts.buildDebugSummary(artifacts, currentModelFile)
+    }
+
+    fun suggestedArtifactFilename(kind: ExportArtifactKind): String? {
+        val artifacts = getExportableModelArtifacts() ?: return null
+        return ModelExportArtifacts.suggestedFilename(artifacts.sourceDisplayName, kind)
+    }
+
+    fun exportArtifactTo(
+        kind: ExportArtifactKind,
+        targetUri: Uri,
+        onResult: (Result<Unit>) -> Unit
+    ) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val result = runCatching {
+                val context = getApplication<Application>()
+                val artifacts = getExportableModelArtifacts()
+                    ?: error("No exportable model artifacts are available")
+                val sourceFile = artifacts.fileFor(kind)
+                    ?: error("Requested export artifact is unavailable")
+                context.contentResolver.openOutputStream(targetUri, "w")?.use { out ->
+                    sourceFile.inputStream().use { input -> input.copyTo(out) }
+                } ?: error("Could not open export destination")
+                diagnostics.recordEvent(
+                    "model_artifact_exported",
+                    mapOf(
+                        "kind" to kind.name,
+                        "sourceDisplayName" to artifacts.sourceDisplayName,
+                        "selectedPlateId" to artifacts.selectedPlateId,
+                        "artifactPath" to sourceFile.absolutePath,
+                        "destinationUri" to targetUri.toString()
+                    )
+                )
+            }.onFailure { error ->
+                diagnostics.recordEvent(
+                    "model_artifact_export_failed",
+                    mapOf(
+                        "kind" to kind.name,
+                        "destinationUri" to targetUri.toString(),
+                        "error" to (error.message ?: error.javaClass.simpleName)
+                    )
+                )
+            }
+            withContext(Dispatchers.Main) {
+                onResult(result)
             }
         }
     }

--- a/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
@@ -365,6 +365,9 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
     private var _multiPlateSourceFile: File? = null
     // Tracks the in-flight selectPlate coroutine so rapid plate changes cancel the prior one.
     private var selectPlateJob: Job? = null
+    // Tracks the in-flight slice coroutine so a plate switch can cancel it before it writes
+    // SliceComplete/Error and overwrites the Loading state set by selectPlate().
+    private var slicingJob: Job? = null
     // Original Bambu file's project_settings.config, parsed before process() strips it.
     // Used by embedProfile() so the file's own settings (enable_support, etc.) survive
     // through the sanitize→embed→extractPlate→restructure→re-embed pipeline.
@@ -1026,6 +1029,7 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
      */
     fun selectPlate(plateId: Int) {
         selectPlateJob?.cancel()
+        slicingJob?.cancel()
         _showPlateSelector.value = false
         // Always extract from the full processed multi-plate file so that switching plates
         // (e.g. plate 4 → plate 5) uses the correct source regardless of prior selections.
@@ -1990,7 +1994,7 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
         // fails early or throws — avoids leaking a full-resolution screen-capture Bitmap.
         val capturedBitmap = pendingThumbnailBitmap.also { pendingThumbnailBitmap = null }
         _sliceStale.value = false
-        viewModelScope.launch(Dispatchers.IO) {
+        slicingJob = viewModelScope.launch(Dispatchers.IO) {
             val context = getApplication<Application>()
             try {
                 when (_state.value) {
@@ -2336,6 +2340,7 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
                             Log.i("SlicerVM", "Thumbnails injected from GL capture")
                         }
                     } catch (e: Throwable) {
+                        if (e is CancellationException) throw e
                         Log.w("SlicerVM", "Thumbnail injection failed (non-fatal): ${e.message}")
                     }
 
@@ -2399,6 +2404,7 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
                     _state.value = SlicerState.Error(clipperUserMessage(errorMsg))
                 }
             } catch (e: Throwable) {
+                if (e is CancellationException) throw e
                 Log.e("SlicerVM", "Unexpected error during slicing", e)
                 val errorMsg = e.message ?: e.javaClass.simpleName
                 if (isClipperError(errorMsg)) {

--- a/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
@@ -36,7 +36,10 @@ import com.u1.slicer.gcode.ParsedGcode
 import com.u1.slicer.gcode.buildSuspiciousModelLineContexts
 import com.u1.slicer.model.CopyArrangeCalculator
 import org.json.JSONObject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -357,6 +360,8 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
     // Full processed multi-plate file — set once on load, never replaced by per-plate
     // extractions so selectPlate() always calls extractPlate() on the right source.
     private var _multiPlateSourceFile: File? = null
+    // Tracks the in-flight selectPlate coroutine so rapid plate changes cancel the prior one.
+    private var selectPlateJob: Job? = null
     // Original Bambu file's project_settings.config, parsed before process() strips it.
     // Used by embedProfile() so the file's own settings (enable_support, etc.) survive
     // through the sanitize→embed→extractPlate→restructure→re-embed pipeline.
@@ -1014,6 +1019,7 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
      * Called when user selects a plate from the multi-plate dialog.
      */
     fun selectPlate(plateId: Int) {
+        selectPlateJob?.cancel()
         _showPlateSelector.value = false
         // Always extract from the full processed multi-plate file so that switching plates
         // (e.g. plate 4 → plate 5) uses the correct source regardless of prior selections.
@@ -1037,7 +1043,7 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
             )
         )
 
-        viewModelScope.launch(Dispatchers.IO) {
+        selectPlateJob = viewModelScope.launch(Dispatchers.IO) {
             try {
                 val context = getApplication<Application>()
                 val workspaceDir = transientWorkspaceDir()
@@ -1055,9 +1061,11 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
                     hasPlateJsons = hasPlateJsons,
                     plateObjectIds = plateObjectIds,
                     objectExtruderMap = plateExtruderMap)
+                ensureActive()
                 // Restructure per-plate: inline component meshes so OrcaSlicer
                 // can assign per-volume extruders (deferred from process()).
                 val plateFile = BambuSanitizer.restructurePlateFile(rawPlateFile, workspaceDir)
+                ensureActive()
                 // Lightweight parse: only reads model_settings.config (~1KB) for extruder
                 // indices, skips the 15MB+ main model XML entirely (~2s saved).
                 val plateInfo = ThreeMfParser.parseForPlateSelection(plateFile)
@@ -1082,9 +1090,11 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
                 // original file's layer-change settings (SEMM/pause G-code), not just
                 // the preview metadata merged above.
                 val embeddedPlateFile = embedProfile(plateFile, mergedPlateInfo, workspaceDir)
+                ensureActive()
                 currentModelFile = embeddedPlateFile
                 loadNativeModel(embeddedPlateFile)
             } catch (e: Throwable) {
+                if (e is CancellationException) throw e
                 NativeLibrary.previewMutex.withLock { native.clearModel() }
                 _state.value = SlicerState.Error("Error extracting plate: ${e.message}")
             }
@@ -1103,6 +1113,7 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
     }
 
     fun dismissPlateSelector() {
+        selectPlateJob?.cancel()
         _showPlateSelector.value = false
         // Cancel the load — multi-plate files need a plate selection to work correctly.
         // Loading the full file causes off-bed coordinates and Clipper errors (B12).

--- a/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/SlicerViewModel.kt
@@ -1023,6 +1023,12 @@ class SlicerViewModel(application: Application) : AndroidViewModel(application) 
             ?: return
         recoveryPlateId = plateId          // Track for Clipper recovery
         clipperRetryAttempted = false      // New plate = fresh retry allowance
+        // Transition to Loading immediately so InlineModelPreview unmounts.
+        // Without this, the rotation LaunchedEffect fires between _threeMfInfo update
+        // and loadNativeModel completing, hitting the native's stale plate-N cache and
+        // delivering the wrong mesh.  Unmounting ensures the fresh effect fires only
+        // after the correct plate is loaded in native.
+        _state.value = SlicerState.Loading("Loading plate $plateId…")
         diagnostics.recordEvent(
             "plate_selected",
             mapOf(

--- a/app/src/main/java/com/u1/slicer/network/MoonrakerClient.kt
+++ b/app/src/main/java/com/u1/slicer/network/MoonrakerClient.kt
@@ -83,7 +83,10 @@ class MoonrakerClient {
     suspend fun wakeCamera() = withContext(Dispatchers.IO) {
         if (baseUrl.isBlank()) return@withContext
         try {
-            val wsUrl = baseUrl.replace("http://", "ws://").replace("https://", "wss://") + "/websocket"
+            val wsUrl = when {
+                baseUrl.startsWith("https://") -> "wss://" + baseUrl.removePrefix("https://")
+                else -> "ws://" + baseUrl.removePrefix("http://")
+            } + "/websocket"
             val request = Request.Builder().url(wsUrl).build()
             client.newWebSocket(request, object : WebSocketListener() {
                 override fun onOpen(webSocket: WebSocket, response: Response) {

--- a/app/src/main/java/com/u1/slicer/network/MoonrakerClient.kt
+++ b/app/src/main/java/com/u1/slicer/network/MoonrakerClient.kt
@@ -36,9 +36,11 @@ class MoonrakerClient {
      * Returns up to 2 candidates: [primary, alt] where alt keeps the original port.
      * Falls back to legacy mjpeg-streamer path if the list is unavailable.
      * Mirrors the bridge's moonraker.py get_webcams() + _resolve_moonraker_url() logic.
+     * Always appends monitor.jpg as a final fallback candidate.
      */
     suspend fun queryWebcamSnapshotCandidates(): List<String> = withContext(Dispatchers.IO) {
         if (baseUrl.isBlank()) return@withContext emptyList()
+        val monitorUrl = "$baseUrl/server/files/camera/monitor.jpg"
         try {
             val request = Request.Builder().url(url("/server/webcams/list")).get().build()
             val response = client.newCall(request).execute()
@@ -61,7 +63,7 @@ class MoonrakerClient {
                         )
                         if (candidates.isNotEmpty()) {
                             Log.d(TAG, "Webcam candidates: $candidates")
-                            return@withContext candidates
+                            return@withContext candidates + monitorUrl
                         }
                     }
                 }
@@ -69,8 +71,32 @@ class MoonrakerClient {
         } catch (e: Exception) {
             Log.d(TAG, "Webcam list unavailable, using legacy fallback: ${e.message}")
         }
-        // Legacy fallback: mjpeg-streamer style
-        listOf("$baseUrl/webcam/?action=snapshot")
+        // Legacy fallback: mjpeg-streamer style + monitor.jpg
+        listOf("$baseUrl/webcam/?action=snapshot", monitorUrl)
+    }
+
+    /**
+     * Wake the printer's camera keepalive stream by opening a WebSocket connection
+     * and sending camera.start_monitor. Fire-and-forget: closes immediately after opening.
+     * Used to ensure the camera monitor.jpg endpoint is freshly populated.
+     */
+    suspend fun wakeCamera() = withContext(Dispatchers.IO) {
+        if (baseUrl.isBlank()) return@withContext
+        try {
+            val wsUrl = baseUrl.replace("http://", "ws://").replace("https://", "wss://") + "/websocket"
+            val request = Request.Builder().url(wsUrl).build()
+            client.newWebSocket(request, object : WebSocketListener() {
+                override fun onOpen(webSocket: WebSocket, response: Response) {
+                    webSocket.send("""{"jsonrpc":"2.0","id":1000,"method":"camera.start_monitor","params":{"domain":"lan","interval":0}}""")
+                    webSocket.close(1000, null)
+                }
+                override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                    Log.d(TAG, "wakeCamera failed: ${t.message}")
+                }
+            })
+        } catch (e: Exception) {
+            Log.d(TAG, "wakeCamera failed: ${e.message}")
+        }
     }
 
     /** Resolve a possibly-relative webcam URL against baseUrl. Mirrors bridge's _resolve_moonraker_url(). */

--- a/app/src/main/java/com/u1/slicer/network/MoonrakerClient.kt
+++ b/app/src/main/java/com/u1/slicer/network/MoonrakerClient.kt
@@ -77,7 +77,8 @@ class MoonrakerClient {
 
     /**
      * Wake the printer's camera keepalive stream by opening a WebSocket connection
-     * and sending camera.start_monitor. Fire-and-forget: closes immediately after opening.
+     * and sending camera.start_monitor. Fire-and-forget: returns before the WebSocket
+     * handshake completes; the message is sent asynchronously on OkHttp's dispatcher thread.
      * Used to ensure the camera monitor.jpg endpoint is freshly populated.
      */
     suspend fun wakeCamera() = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/u1/slicer/printer/PrinterRepository.kt
+++ b/app/src/main/java/com/u1/slicer/printer/PrinterRepository.kt
@@ -126,6 +126,8 @@ class PrinterRepository(
 
     suspend fun queryWebcamSnapshotCandidates(): List<String> = client.queryWebcamSnapshotCandidates()
 
+    suspend fun wakeCamera() = client.wakeCamera()
+
     suspend fun queryFilamentSlots(): List<FilamentSlot>? = client.queryFilamentSlots()
 
     suspend fun pausePrint(): Boolean = client.pausePrint()

--- a/app/src/main/java/com/u1/slicer/printer/PrinterViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/printer/PrinterViewModel.kt
@@ -62,7 +62,7 @@ class PrinterViewModel(application: Application) : AndroidViewModel(application)
     private var cameraKeepaliveJob: Job? = null
 
     fun startCameraKeepalive() {
-        if (cameraKeepaliveJob?.isActive == true) return
+        if (!shouldStartCameraKeepalive(cameraKeepaliveJob?.isActive == true)) return
         cameraKeepaliveJob = viewModelScope.launch(Dispatchers.IO) {
             while (true) {
                 printerRepo.wakeCamera()
@@ -130,7 +130,7 @@ class PrinterViewModel(application: Application) : AndroidViewModel(application)
                 if (_sendingState.value is SendingState.PrintStarted && s.isPrinting) {
                     _sendingState.value = SendingState.Idle
                 }
-                if (s.isConnected && !wasConnected) {
+                if (shouldPollLedOnConnectionEdge(wasConnected = wasConnected, isConnected = s.isConnected)) {
                     launch(Dispatchers.IO) { pollLedState() }
                 }
                 wasConnected = s.isConnected
@@ -307,5 +307,12 @@ class PrinterViewModel(application: Application) : AndroidViewModel(application)
         super.onCleared()
         stopCameraKeepalive()
         printerRepo.stopPolling()
+    }
+
+    companion object {
+        internal fun shouldStartCameraKeepalive(hasActiveJob: Boolean): Boolean = !hasActiveJob
+
+        internal fun shouldPollLedOnConnectionEdge(wasConnected: Boolean, isConnected: Boolean): Boolean =
+            isConnected && !wasConnected
     }
 }

--- a/app/src/main/java/com/u1/slicer/printer/PrinterViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/printer/PrinterViewModel.kt
@@ -123,11 +123,17 @@ class PrinterViewModel(application: Application) : AndroidViewModel(application)
         // Resolve webcam URLs for the already-saved printer URL (if any)
         viewModelScope.launch(Dispatchers.IO) { resolveWebcam() }
         // Auto-clear the "Print started!" banner once the printer confirms printing.
+        // Also sync LED state on first connection (pollLedState only runs via testConnection otherwise).
         viewModelScope.launch {
+            var wasConnected = false
             status.collect { s ->
                 if (_sendingState.value is SendingState.PrintStarted && s.isPrinting) {
                     _sendingState.value = SendingState.Idle
                 }
+                if (s.isConnected && !wasConnected) {
+                    launch(Dispatchers.IO) { pollLedState() }
+                }
+                wasConnected = s.isConnected
             }
         }
     }

--- a/app/src/main/java/com/u1/slicer/printer/PrinterViewModel.kt
+++ b/app/src/main/java/com/u1/slicer/printer/PrinterViewModel.kt
@@ -9,6 +9,8 @@ import com.u1.slicer.data.defaultExtruderPresets
 import com.u1.slicer.network.FilamentSlot
 import com.u1.slicer.network.PrinterStatus
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -56,6 +58,23 @@ class PrinterViewModel(application: Application) : AndroidViewModel(application)
 
     private val _heaterError = MutableStateFlow<String?>(null)
     val heaterError: StateFlow<String?> = _heaterError.asStateFlow()
+
+    private var cameraKeepaliveJob: Job? = null
+
+    fun startCameraKeepalive() {
+        if (cameraKeepaliveJob?.isActive == true) return
+        cameraKeepaliveJob = viewModelScope.launch(Dispatchers.IO) {
+            while (true) {
+                printerRepo.wakeCamera()
+                delay(2000)
+            }
+        }
+    }
+
+    fun stopCameraKeepalive() {
+        cameraKeepaliveJob?.cancel()
+        cameraKeepaliveJob = null
+    }
 
     fun clearHeaterError() { _heaterError.value = null }
 
@@ -280,6 +299,7 @@ class PrinterViewModel(application: Application) : AndroidViewModel(application)
 
     override fun onCleared() {
         super.onCleared()
+        stopCameraKeepalive()
         printerRepo.stopPolling()
     }
 }

--- a/app/src/main/java/com/u1/slicer/ui/PrinterScreen.kt
+++ b/app/src/main/java/com/u1/slicer/ui/PrinterScreen.kt
@@ -121,6 +121,11 @@ fun PrinterScreen(
         }
     }
 
+    DisposableEffect(Unit) {
+        viewModel.startCameraKeepalive()
+        onDispose { viewModel.stopCameraKeepalive() }
+    }
+
     // Sync preview dialog
     if (syncState is PrinterViewModel.SyncState.Preview) {
         FilamentSyncDialog(

--- a/app/src/test/java/com/u1/slicer/ModelExportArtifactsTest.kt
+++ b/app/src/test/java/com/u1/slicer/ModelExportArtifactsTest.kt
@@ -1,0 +1,159 @@
+package com.u1.slicer
+
+import com.u1.slicer.bambu.ThreeMfInfo
+import com.u1.slicer.bambu.ThreeMfObject
+import com.u1.slicer.bambu.ThreeMfPlate
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import java.nio.file.Files
+
+class ModelExportArtifactsTest {
+    @Test
+    fun current_returnsNull_forNonBambuModels() {
+        val dir = Files.createTempDirectory("export-artifacts").toFile()
+        val sanitized = File(dir, "model.sanitized.3mf").apply { writeText("zip") }
+        val embedded = File(dir, "model.embedded.3mf").apply { writeText("zip") }
+
+        val artifacts = ModelExportArtifacts.current(
+            sourceDisplayName = "model.3mf",
+            selectedPlateId = null,
+            sanitizedFile = sanitized,
+            embeddedFile = embedded,
+            info = sampleInfo(isBambu = false)
+        )
+
+        assertNull(artifacts)
+    }
+
+    @Test
+    fun current_filtersUnavailableArtifacts_andKeepsExportableBambuState() {
+        val dir = Files.createTempDirectory("export-artifacts").toFile()
+        val sanitized = File(dir, "dragon.sanitized.3mf").apply { writeText("zip") }
+        val missingEmbedded = File(dir, "dragon.sanitized-embedded.3mf")
+
+        val artifacts = ModelExportArtifacts.current(
+            sourceDisplayName = "Dragon Scale infinity.3mf",
+            selectedPlateId = 3,
+            sanitizedFile = sanitized,
+            embeddedFile = missingEmbedded,
+            info = sampleInfo(isBambu = true, isMultiPlate = true)
+        )
+
+        assertNotNull(artifacts)
+        assertEquals(sanitized, artifacts!!.fileFor(ExportArtifactKind.Sanitized3mf))
+        assertNull(artifacts.fileFor(ExportArtifactKind.SanitizedEmbedded3mf))
+        assertEquals(3, artifacts.selectedPlateId)
+    }
+
+    @Test
+    fun current_returnsNull_whenNoExportableArtifactsRemain() {
+        val dir = Files.createTempDirectory("export-artifacts").toFile()
+        val sanitized = File(dir, "dragon.sanitized.tmp").apply { writeText("not-3mf") }
+        val embedded = File(dir, "dragon.sanitized-embedded.3mf")
+
+        val artifacts = ModelExportArtifacts.current(
+            sourceDisplayName = "",
+            selectedPlateId = null,
+            sanitizedFile = sanitized,
+            embeddedFile = embedded,
+            info = sampleInfo(isBambu = true)
+        )
+
+        assertNull(artifacts)
+    }
+
+    @Test
+    fun suggestedFilename_usesKnownSuffixes() {
+        assertEquals(
+            "Dragon Scale infinity.sanitized.3mf",
+            ModelExportArtifacts.suggestedFilename(
+                "Dragon Scale infinity.3mf",
+                ExportArtifactKind.Sanitized3mf
+            )
+        )
+        assertEquals(
+            "Dragon Scale infinity.sanitized-embedded.3mf",
+            ModelExportArtifacts.suggestedFilename(
+                "Dragon Scale infinity.3mf",
+                ExportArtifactKind.SanitizedEmbedded3mf
+            )
+        )
+    }
+
+    @Test
+    fun suggestedFilename_fallsBackToModel_whenSourceNameBlank() {
+        assertEquals(
+            "model.sanitized.3mf",
+            ModelExportArtifacts.suggestedFilename(
+                "",
+                ExportArtifactKind.Sanitized3mf
+            )
+        )
+    }
+
+    @Test
+    fun buildDebugSummary_includesStageContractFields() {
+        val dir = Files.createTempDirectory("export-artifacts").toFile()
+        val sanitized = File(dir, "dragon.sanitized.3mf").apply { writeText("zip") }
+        val embedded = File(dir, "dragon.sanitized-embedded.3mf").apply { writeText("zip") }
+        val artifacts = ModelExportArtifacts.current(
+            sourceDisplayName = "Dragon Scale infinity.3mf",
+            selectedPlateId = 3,
+            sanitizedFile = sanitized,
+            embeddedFile = embedded,
+            info = sampleInfo(
+                isBambu = true,
+                isMultiPlate = true,
+                hasPaintData = true,
+                hasPaintSupports = true,
+                hasLayerToolChanges = true,
+                detectedExtruderCount = 4,
+                usedExtruderIndices = setOf(1, 3, 4),
+                objectExtruderMap = mapOf("11" to 1, "12" to 3)
+            )
+        )!!
+
+        val summary = ModelExportArtifacts.buildDebugSummary(artifacts, embedded)
+
+        assertTrue(summary.contains("Source file: Dragon Scale infinity.3mf"))
+        assertTrue(summary.contains("Current working file: dragon.sanitized-embedded.3mf"))
+        assertTrue(summary.contains("Bambu file: yes"))
+        assertTrue(summary.contains("Multi-plate: yes"))
+        assertTrue(summary.contains("Selected plate: 3"))
+        assertTrue(summary.contains("Detected extruders: 4"))
+        assertTrue(summary.contains("Paint data: yes"))
+        assertTrue(summary.contains("Paint supports: yes"))
+        assertTrue(summary.contains("Layer-tool changes: yes"))
+        assertTrue(summary.contains("Used extruder indices: 1, 3, 4"))
+        assertTrue(summary.contains("Object-extruder map size: 2"))
+        assertTrue(summary.contains("Sanitized artifact: dragon.sanitized.3mf"))
+        assertTrue(summary.contains("Sanitized + embedded artifact: dragon.sanitized-embedded.3mf"))
+    }
+
+    private fun sampleInfo(
+        isBambu: Boolean,
+        isMultiPlate: Boolean = false,
+        hasPaintData: Boolean = false,
+        hasPaintSupports: Boolean = false,
+        hasLayerToolChanges: Boolean = false,
+        detectedExtruderCount: Int = 1,
+        usedExtruderIndices: Set<Int> = emptySet(),
+        objectExtruderMap: Map<String, Int> = emptyMap()
+    ): ThreeMfInfo = ThreeMfInfo(
+        objects = listOf(ThreeMfObject("11", "Test Object")),
+        plates = if (isMultiPlate) listOf(ThreeMfPlate(3, "Plate 3", listOf("11"))) else emptyList(),
+        isBambu = isBambu,
+        isMultiPlate = isMultiPlate,
+        hasPaintData = hasPaintData,
+        hasPaintSupports = hasPaintSupports,
+        hasLayerToolChanges = hasLayerToolChanges,
+        detectedExtruderCount = detectedExtruderCount,
+        usedExtruderIndices = usedExtruderIndices,
+        objectExtruderMap = objectExtruderMap
+    )
+}

--- a/app/src/test/java/com/u1/slicer/network/MoonrakerClientTest.kt
+++ b/app/src/test/java/com/u1/slicer/network/MoonrakerClientTest.kt
@@ -395,6 +395,48 @@ class MoonrakerClientTest {
         assertEquals("SET_HEATER_TEMPERATURE HEATER=extruder TARGET=300",
             MoonrakerClient.buildSetHeaterGcode("extruder", 999))
     }
+
+    @Test
+    fun `queryWebcamSnapshotCandidates with empty webcam list appends monitor jpg as last candidate`() = runTest {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setBody("""{"result":{"webcams":[]}}"""))
+        server.start()
+        val client = MoonrakerClient()
+        client.baseUrl = server.url("/").toString()
+        val candidates = client.queryWebcamSnapshotCandidates()
+        assertTrue("Expected at least 2 candidates", candidates.size >= 2)
+        assertTrue(
+            "Last candidate must be monitor.jpg, got: ${candidates.last()}",
+            candidates.last().endsWith("/server/files/camera/monitor.jpg")
+        )
+        server.shutdown()
+    }
+
+    @Test
+    fun `queryWebcamSnapshotCandidates with configured webcam appends monitor jpg after existing candidates`() = runTest {
+        val server = MockWebServer()
+        server.enqueue(MockResponse().setBody("""
+            {"result":{"webcams":[{
+                "name":"Camera","enabled":true,
+                "snapshot_url":"/webcam/?action=snapshot",
+                "stream_url":"/webcam/?action=stream"
+            }]}}
+        """.trimIndent()))
+        server.start()
+        val client = MoonrakerClient()
+        client.baseUrl = server.url("/").toString()
+        val candidates = client.queryWebcamSnapshotCandidates()
+        assertTrue("Expected at least 2 candidates", candidates.size >= 2)
+        assertTrue(
+            "Last candidate must be monitor.jpg, got: ${candidates.last()}",
+            candidates.last().endsWith("/server/files/camera/monitor.jpg")
+        )
+        assertFalse(
+            "First candidate must not be monitor.jpg",
+            candidates.first().contains("monitor.jpg")
+        )
+        server.shutdown()
+    }
 }
 
 // MoonrakerClientTestHelper removed — tests now use MoonrakerClient.normalizeUrl() directly.

--- a/app/src/test/java/com/u1/slicer/printer/PrinterViewModelTest.kt
+++ b/app/src/test/java/com/u1/slicer/printer/PrinterViewModelTest.kt
@@ -1,0 +1,29 @@
+package com.u1.slicer.printer
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PrinterViewModelTest {
+    @Test
+    fun `shouldStartCameraKeepalive returns false when job already active`() {
+        assertFalse(PrinterViewModel.shouldStartCameraKeepalive(hasActiveJob = true))
+    }
+
+    @Test
+    fun `shouldStartCameraKeepalive returns true when no active job exists`() {
+        assertTrue(PrinterViewModel.shouldStartCameraKeepalive(hasActiveJob = false))
+    }
+
+    @Test
+    fun `shouldPollLedOnConnectionEdge returns true only on rising connection edge`() {
+        assertTrue(PrinterViewModel.shouldPollLedOnConnectionEdge(wasConnected = false, isConnected = true))
+        assertFalse(PrinterViewModel.shouldPollLedOnConnectionEdge(wasConnected = true, isConnected = true))
+        assertFalse(PrinterViewModel.shouldPollLedOnConnectionEdge(wasConnected = true, isConnected = false))
+    }
+
+    @Test
+    fun `shouldPollLedOnConnectionEdge ignores disconnected steady state`() {
+        assertFalse(PrinterViewModel.shouldPollLedOnConnectionEdge(wasConnected = false, isConnected = false))
+    }
+}

--- a/docs/superpowers/plans/2026-04-21-f73-multi-plate-nav.md
+++ b/docs/superpowers/plans/2026-04-21-f73-multi-plate-nav.md
@@ -1,0 +1,237 @@
+# F73: Multi-Plate Navigation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users switch plates from the Prepare screen without reloading the file, by adding a "Change plate" chip and wiring it to the existing plate selector dialog.
+
+**Architecture:** `SlicerViewModel` gets a new `multiPlatePlates` StateFlow (the stable original plates list) and `reopenPlateSelector()`. The Prepare screen collects `multiPlatePlates`, passes it to `PlateSelectDialog` (replacing the stale post-selection `threeMfInfo!!.plates`), and shows an `AssistChip` that triggers the reopen. No native changes.
+
+**Tech Stack:** Kotlin StateFlow, Jetpack Compose `AssistChip`, existing `PlateSelectDialog`.
+
+---
+
+## Files
+
+| File | Change |
+|---|---|
+| `app/src/main/java/com/u1/slicer/SlicerViewModel.kt` | Add `_multiPlatePlates` StateFlow; set/clear alongside `_fileThreeMfInfo`; add `reopenPlateSelector()` |
+| `app/src/main/java/com/u1/slicer/MainActivity.kt` | Collect `multiPlatePlates`; update `PlateSelectDialog` call; add `AssistChip` |
+
+No new files. No native changes.
+
+---
+
+## Task 1: ViewModel — multiPlatePlates StateFlow + reopenPlateSelector()
+
+**Files:**
+- Modify: `app/src/main/java/com/u1/slicer/SlicerViewModel.kt`
+
+- [ ] **Step 1: Add the new StateFlow field**
+
+Find this block (around line 197–200):
+```kotlin
+    private var _fileThreeMfInfo: ThreeMfInfo? = null
+
+    private val _showPlateSelector = MutableStateFlow(false)
+    val showPlateSelector: StateFlow<Boolean> = _showPlateSelector.asStateFlow()
+```
+
+Add the new field between `_fileThreeMfInfo` and `_showPlateSelector`:
+```kotlin
+    private var _fileThreeMfInfo: ThreeMfInfo? = null
+
+    private val _multiPlatePlates = MutableStateFlow<List<com.u1.slicer.bambu.PlateInfo>>(emptyList())
+    val multiPlatePlates: StateFlow<List<com.u1.slicer.bambu.PlateInfo>> = _multiPlatePlates.asStateFlow()
+
+    private val _showPlateSelector = MutableStateFlow(false)
+    val showPlateSelector: StateFlow<Boolean> = _showPlateSelector.asStateFlow()
+```
+
+- [ ] **Step 2: Populate multiPlatePlates on load**
+
+Find this block (around line 1581–1585):
+```kotlin
+        _threeMfInfo.value = mergedInfo
+        _fileThreeMfInfo = mergedInfo
+        sourceModelFile = processed
+        sourceModelInfo = processedInfo
+        if (origInfo.isMultiPlate) _multiPlateSourceFile = processed
+```
+
+Add `_multiPlatePlates` assignment on the line after `_fileThreeMfInfo = mergedInfo`:
+```kotlin
+        _threeMfInfo.value = mergedInfo
+        _fileThreeMfInfo = mergedInfo
+        _multiPlatePlates.value = if (origInfo.isMultiPlate) mergedInfo.plates else emptyList()
+        sourceModelFile = processed
+        sourceModelInfo = processedInfo
+        if (origInfo.isMultiPlate) _multiPlateSourceFile = processed
+```
+
+- [ ] **Step 3: Clear multiPlatePlates in dismissPlateSelector()**
+
+Find `fun dismissPlateSelector()` (around line 1091). It currently ends with:
+```kotlin
+        _multiPlateSourceFile = null
+        _threeMfInfo.value = null
+        _fileThreeMfInfo = null
+    }
+```
+
+Add `_multiPlatePlates.value = emptyList()` after `_fileThreeMfInfo = null`:
+```kotlin
+        _multiPlateSourceFile = null
+        _threeMfInfo.value = null
+        _fileThreeMfInfo = null
+        _multiPlatePlates.value = emptyList()
+    }
+```
+
+- [ ] **Step 4: Clear multiPlatePlates in the new-model reset block**
+
+Find the block that clears model state (around line 2952–2954):
+```kotlin
+        _fileThreeMfInfo = null
+        _multiPlateSourceFile = null
+        _showPlateSelector.value = false
+```
+
+Add `_multiPlatePlates.value = emptyList()` after `_fileThreeMfInfo = null`:
+```kotlin
+        _fileThreeMfInfo = null
+        _multiPlatePlates.value = emptyList()
+        _multiPlateSourceFile = null
+        _showPlateSelector.value = false
+```
+
+- [ ] **Step 5: Add reopenPlateSelector()**
+
+Find `fun dismissPlateSelector()`. Add `reopenPlateSelector()` directly after its closing `}`:
+```kotlin
+    fun reopenPlateSelector() {
+        if (_multiPlatePlates.value.isNotEmpty()) _showPlateSelector.value = true
+    }
+```
+
+- [ ] **Step 6: Build to confirm no compile errors**
+
+```bash
+cd c:/Users/kevin/projects/u1-slicer-orca
+./gradlew compileDebugKotlin --no-daemon --no-build-cache
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 7: Run unit tests**
+
+```bash
+./gradlew testDebugUnitTest --no-daemon
+```
+
+Expected: all 821 tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/src/main/java/com/u1/slicer/SlicerViewModel.kt
+git commit -m "feat(F73): multiPlatePlates StateFlow + reopenPlateSelector in SlicerViewModel"
+```
+
+---
+
+## Task 2: UI — PlateSelectDialog fix + AssistChip
+
+**Files:**
+- Modify: `app/src/main/java/com/u1/slicer/MainActivity.kt`
+
+- [ ] **Step 1: Collect multiPlatePlates in the Prepare screen**
+
+Find the block of `collectAsState()` calls near the top of the Prepare composable (around line 762–765):
+```kotlin
+    val showPlateSelector by viewModel.showPlateSelector.collectAsState()
+    val showMultiColorDialog by viewModel.showMultiColorDialog.collectAsState()
+    val colorMapping by viewModel.colorMapping.collectAsState()
+    val threeMfInfo by viewModel.threeMfInfo.collectAsState()
+```
+
+Add `multiPlatePlates` collection after `showPlateSelector`:
+```kotlin
+    val showPlateSelector by viewModel.showPlateSelector.collectAsState()
+    val multiPlatePlates by viewModel.multiPlatePlates.collectAsState()
+    val showMultiColorDialog by viewModel.showMultiColorDialog.collectAsState()
+    val colorMapping by viewModel.colorMapping.collectAsState()
+    val threeMfInfo by viewModel.threeMfInfo.collectAsState()
+```
+
+- [ ] **Step 2: Fix PlateSelectDialog to use multiPlatePlates**
+
+Find the existing dialog block (around line 782–789):
+```kotlin
+    // Plate selector dialog
+    if (showPlateSelector && threeMfInfo != null) {
+        com.u1.slicer.ui.PlateSelectDialog(
+            plates = threeMfInfo!!.plates,
+            onSelect = { viewModel.selectPlate(it) },
+            onDismiss = { viewModel.dismissPlateSelector() },
+            info = threeMfInfo
+        )
+    }
+```
+
+Replace with:
+```kotlin
+    // Plate selector dialog
+    if (showPlateSelector && multiPlatePlates.isNotEmpty()) {
+        com.u1.slicer.ui.PlateSelectDialog(
+            plates = multiPlatePlates,
+            onSelect = { viewModel.selectPlate(it) },
+            onDismiss = { viewModel.dismissPlateSelector() },
+            info = threeMfInfo
+        )
+    }
+```
+
+- [ ] **Step 3: Add the "Change plate" AssistChip**
+
+Find the `PrintSetupSection(...)` call (around line 986–1000). Add the chip immediately before it:
+```kotlin
+                        // Change plate chip — visible when a multi-plate file is loaded
+                        if (multiPlatePlates.isNotEmpty()) {
+                            AssistChip(
+                                onClick = { viewModel.reopenPlateSelector() },
+                                label = { Text("Change plate") },
+                                leadingIcon = {
+                                    Icon(
+                                        Icons.Default.Layers,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(16.dp)
+                                    )
+                                }
+                            )
+                        }
+                        // Inline extruder/color assignment + prime tower toggle
+                        PrintSetupSection(
+```
+
+- [ ] **Step 4: Build to confirm no compile errors**
+
+```bash
+./gradlew compileDebugKotlin --no-daemon --no-build-cache
+```
+
+Expected: `BUILD SUCCESSFUL`.
+
+- [ ] **Step 5: Run unit tests**
+
+```bash
+./gradlew testDebugUnitTest --no-daemon
+```
+
+Expected: all 821 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/src/main/java/com/u1/slicer/MainActivity.kt
+git commit -m "feat(F73): Change plate chip + fix PlateSelectDialog to use stable plates list"
+```

--- a/docs/superpowers/plans/2026-04-21-f74-finer-scaling.md
+++ b/docs/superpowers/plans/2026-04-21-f74-finer-scaling.md
@@ -1,0 +1,260 @@
+# F74: Finer Model Scaling — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the stepped scale slider (10% increments) with a continuous slider + editable percentage text field so users can set any scale from 10%–300%.
+
+**Architecture:** Single composable change in `ScaleSection` — remove `steps = 28` from all scale sliders, replace the read-only `Text("Scale: $pct")` / `Text("$axis: $pct")` labels with `OutlinedTextField` widgets that accept direct numeric entry. Three new imports required.
+
+**Tech Stack:** Jetpack Compose, Material3, `KeyboardActions`, `ImeAction`, `LocalFocusManager`.
+
+---
+
+## Files
+
+| File | Change |
+|---|---|
+| `app/src/main/java/com/u1/slicer/MainActivity.kt` | Add 3 imports; replace scale label+slider blocks with label+textfield+slider in `ScaleSection` |
+
+No ViewModel changes. No tests (pure UI composition change).
+
+---
+
+## Task 1: Add imports and update ScaleSection
+
+**Files:**
+- Modify: `app/src/main/java/com/u1/slicer/MainActivity.kt`
+
+- [ ] **Step 1: Add 3 missing imports**
+
+Find the existing import block around line 41–42:
+```kotlin
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
+```
+
+Add immediately after those two lines:
+```kotlin
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.platform.LocalFocusManager
+```
+
+- [ ] **Step 2: Replace the scale label + slider blocks in `ScaleSection`**
+
+Find this block (starts around line 3099, inside the `if (selectedTab == 0)` branch, after the `Divider`):
+
+```kotlin
+                        if (uniformMode) {
+                            val pct = "%.0f%%".format(uniformValue * 100)
+                            Text("Scale: $pct", style = MaterialTheme.typography.labelMedium)
+                            Slider(
+                                value = uniformValue,
+                                onValueChange = { v ->
+                                    uniformValue = v
+                                    onScaleChange(SlicerViewModel.ModelScale(v, v, v))
+                                },
+                                valueRange = 0.1f..3f,
+                                steps = 28
+                            )
+                        } else {
+                            listOf("X" to scale.x, "Y" to scale.y, "Z" to scale.z).forEach { (axis, v) ->
+                                Text("$axis: ${"%.0f%%".format(v * 100)}", style = MaterialTheme.typography.labelMedium)
+                                Slider(
+                                    value = v,
+                                    onValueChange = { nv ->
+                                        val ns = when (axis) {
+                                            "X" -> scale.copy(x = nv)
+                                            "Y" -> scale.copy(y = nv)
+                                            else -> scale.copy(z = nv)
+                                        }
+                                        onScaleChange(ns)
+                                    },
+                                    valueRange = 0.1f..3f,
+                                    steps = 28
+                                )
+                            }
+                        }
+```
+
+Replace it with:
+
+```kotlin
+                        val focusManager = LocalFocusManager.current
+                        if (uniformMode) {
+                            var uniformText by remember(uniformValue) {
+                                mutableStateOf("%.0f".format(uniformValue * 100))
+                            }
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text("Scale", style = MaterialTheme.typography.labelMedium)
+                                OutlinedTextField(
+                                    value = uniformText,
+                                    onValueChange = { uniformText = it },
+                                    suffix = { Text("%") },
+                                    keyboardOptions = KeyboardOptions(
+                                        keyboardType = KeyboardType.Number,
+                                        imeAction = ImeAction.Done
+                                    ),
+                                    keyboardActions = KeyboardActions(onDone = {
+                                        val v = uniformText.toFloatOrNull()
+                                            ?.div(100f)?.coerceIn(0.1f, 3f) ?: uniformValue
+                                        uniformValue = v
+                                        uniformText = "%.0f".format(v * 100)
+                                        onScaleChange(SlicerViewModel.ModelScale(v, v, v))
+                                        focusManager.clearFocus()
+                                    }),
+                                    singleLine = true,
+                                    modifier = Modifier.width(96.dp)
+                                )
+                            }
+                            Slider(
+                                value = uniformValue,
+                                onValueChange = { v ->
+                                    uniformValue = v
+                                    uniformText = "%.0f".format(v * 100)
+                                    onScaleChange(SlicerViewModel.ModelScale(v, v, v))
+                                },
+                                valueRange = 0.1f..3f
+                            )
+                        } else {
+                            var xText by remember(scale.x) {
+                                mutableStateOf("%.0f".format(scale.x * 100))
+                            }
+                            var yText by remember(scale.y) {
+                                mutableStateOf("%.0f".format(scale.y * 100))
+                            }
+                            var zText by remember(scale.z) {
+                                mutableStateOf("%.0f".format(scale.z * 100))
+                            }
+                            // X
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text("X", style = MaterialTheme.typography.labelMedium)
+                                OutlinedTextField(
+                                    value = xText,
+                                    onValueChange = { xText = it },
+                                    suffix = { Text("%") },
+                                    keyboardOptions = KeyboardOptions(
+                                        keyboardType = KeyboardType.Number,
+                                        imeAction = ImeAction.Done
+                                    ),
+                                    keyboardActions = KeyboardActions(onDone = {
+                                        val v = xText.toFloatOrNull()
+                                            ?.div(100f)?.coerceIn(0.1f, 3f) ?: scale.x
+                                        xText = "%.0f".format(v * 100)
+                                        onScaleChange(scale.copy(x = v))
+                                        focusManager.clearFocus()
+                                    }),
+                                    singleLine = true,
+                                    modifier = Modifier.width(96.dp)
+                                )
+                            }
+                            Slider(
+                                value = scale.x,
+                                onValueChange = { nv ->
+                                    xText = "%.0f".format(nv * 100)
+                                    onScaleChange(scale.copy(x = nv))
+                                },
+                                valueRange = 0.1f..3f
+                            )
+                            // Y
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text("Y", style = MaterialTheme.typography.labelMedium)
+                                OutlinedTextField(
+                                    value = yText,
+                                    onValueChange = { yText = it },
+                                    suffix = { Text("%") },
+                                    keyboardOptions = KeyboardOptions(
+                                        keyboardType = KeyboardType.Number,
+                                        imeAction = ImeAction.Done
+                                    ),
+                                    keyboardActions = KeyboardActions(onDone = {
+                                        val v = yText.toFloatOrNull()
+                                            ?.div(100f)?.coerceIn(0.1f, 3f) ?: scale.y
+                                        yText = "%.0f".format(v * 100)
+                                        onScaleChange(scale.copy(y = v))
+                                        focusManager.clearFocus()
+                                    }),
+                                    singleLine = true,
+                                    modifier = Modifier.width(96.dp)
+                                )
+                            }
+                            Slider(
+                                value = scale.y,
+                                onValueChange = { nv ->
+                                    yText = "%.0f".format(nv * 100)
+                                    onScaleChange(scale.copy(y = nv))
+                                },
+                                valueRange = 0.1f..3f
+                            )
+                            // Z
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text("Z", style = MaterialTheme.typography.labelMedium)
+                                OutlinedTextField(
+                                    value = zText,
+                                    onValueChange = { zText = it },
+                                    suffix = { Text("%") },
+                                    keyboardOptions = KeyboardOptions(
+                                        keyboardType = KeyboardType.Number,
+                                        imeAction = ImeAction.Done
+                                    ),
+                                    keyboardActions = KeyboardActions(onDone = {
+                                        val v = zText.toFloatOrNull()
+                                            ?.div(100f)?.coerceIn(0.1f, 3f) ?: scale.z
+                                        zText = "%.0f".format(v * 100)
+                                        onScaleChange(scale.copy(z = v))
+                                        focusManager.clearFocus()
+                                    }),
+                                    singleLine = true,
+                                    modifier = Modifier.width(96.dp)
+                                )
+                            }
+                            Slider(
+                                value = scale.z,
+                                onValueChange = { nv ->
+                                    zText = "%.0f".format(nv * 100)
+                                    onScaleChange(scale.copy(z = nv))
+                                },
+                                valueRange = 0.1f..3f
+                            )
+                        }
+```
+
+- [ ] **Step 3: Build and verify no compile errors**
+
+```bash
+cd c:/Users/kevin/projects/u1-slicer-orca
+./gradlew compileDebugKotlin --no-daemon --no-build-cache
+```
+
+Expected: `BUILD SUCCESSFUL`. Fix any import or type errors before continuing.
+
+- [ ] **Step 4: Run unit tests to confirm no regressions**
+
+```bash
+./gradlew testDebugUnitTest --no-daemon
+```
+
+Expected: all 821 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/u1/slicer/MainActivity.kt
+git commit -m "feat(F74): continuous scale slider + editable percentage text field"
+```

--- a/docs/superpowers/specs/2026-04-21-f73-multi-plate-nav-design.md
+++ b/docs/superpowers/specs/2026-04-21-f73-multi-plate-nav-design.md
@@ -1,0 +1,122 @@
+# F73: Multi-Plate Navigation — Design Spec
+
+**Date:** 2026-04-21
+**Feature:** Change plate without reloading the file
+
+---
+
+## Problem
+
+After loading a multi-plate 3MF and selecting a plate, returning to the plate picker requires exiting and fully reloading the file. The native model is already in memory — re-selection is fast, but the UI offers no way to trigger it.
+
+---
+
+## Goal
+
+Let the user switch to a different plate from the Prepare screen with one tap, without reloading the file.
+
+---
+
+## Key Insight
+
+`_multiPlateSourceFile` (the full processed 3MF) and `_fileThreeMfInfo` (the original file-level `ThreeMfInfo` with all plates) both survive `selectPlate()` — they are only cleared by `dismissPlateSelector()` (cancel) or loading a new model. Re-opening the dialog just requires setting `_showPlateSelector.value = true` again, but the dialog needs to read plates from `_fileThreeMfInfo` (not the post-selection `_threeMfInfo`, which only has the single selected plate).
+
+---
+
+## Design
+
+### `SlicerViewModel.kt`
+
+**New state:**
+
+```kotlin
+private val _multiPlatePlates = MutableStateFlow<List<com.u1.slicer.bambu.PlateInfo>>(emptyList())
+val multiPlatePlates: StateFlow<List<com.u1.slicer.bambu.PlateInfo>> = _multiPlatePlates.asStateFlow()
+```
+
+**Set** at the point where `_fileThreeMfInfo = mergedInfo` is assigned (line ~1582):
+```kotlin
+_multiPlatePlates.value = if (mergedInfo.isMultiPlate) mergedInfo.plates else emptyList()
+```
+
+**Clear** wherever `_fileThreeMfInfo = null` is assigned (dismissPlateSelector ~line 1101, newModel ~line 2952):
+```kotlin
+_multiPlatePlates.value = emptyList()
+```
+
+**New function:**
+
+```kotlin
+fun reopenPlateSelector() {
+    if (_multiPlatePlates.value.isNotEmpty()) _showPlateSelector.value = true
+}
+```
+
+### `MainActivity.kt` — Prepare screen composable
+
+**Update dialog call** to use `multiPlatePlates` instead of `threeMfInfo!!.plates` (which is empty after the first selection):
+
+```kotlin
+val multiPlatePlates by viewModel.multiPlatePlates.collectAsState()
+
+if (showPlateSelector && multiPlatePlates.isNotEmpty()) {
+    PlateSelectDialog(
+        plates = multiPlatePlates,
+        ...
+    )
+}
+```
+
+**Add "Change plate" chip** — visible when `multiPlatePlates.isNotEmpty()` and state is `ModelLoaded` or `SliceComplete`. Placement: below the colour chip row, above the Scale card.
+
+```kotlin
+if (multiPlatePlates.isNotEmpty()) {
+    AssistChip(
+        onClick = { viewModel.reopenPlateSelector() },
+        label = { Text("Change plate") },
+        leadingIcon = { Icon(Icons.Default.Layers, contentDescription = null, Modifier.size(16.dp)) }
+    )
+}
+```
+
+---
+
+## Data Flow
+
+```
+User taps "Change plate"
+  → reopenPlateSelector() → _showPlateSelector.value = true
+  → PlateSelectDialog shown with multiPlatePlates (original full list)
+  → User selects plate N
+  → selectPlate(N) → _showPlateSelector = false → extract + embed + load
+  → multiPlatePlates unchanged (still full list, ready for another change)
+
+User taps Cancel in dialog
+  → dismissPlateSelector() → _showPlateSelector = false
+  → _multiPlatePlates.value = emptyList() (chip disappears)
+  → _multiPlateSourceFile = null, _fileThreeMfInfo = null
+  → Idle state
+```
+
+Note: Cancel from a reopen clears everything (same as the original cancel). This is correct — the user explicitly dismissed.
+
+---
+
+## Files
+
+| File | Change |
+|---|---|
+| `app/src/main/java/com/u1/slicer/SlicerViewModel.kt` | Add `_multiPlatePlates` StateFlow, set/clear alongside `_fileThreeMfInfo`, add `reopenPlateSelector()` |
+| `app/src/main/java/com/u1/slicer/MainActivity.kt` | Collect `multiPlatePlates`, update `PlateSelectDialog` call, add `AssistChip` |
+
+No new files. No native changes.
+
+---
+
+## Tests
+
+Unit test in `SlicerViewModelTest` or a new `MultiPlateNavTest`:
+- `multiPlatePlates` is populated after a multi-plate load and survives `selectPlate()`
+- `multiPlatePlates` is cleared after `dismissPlateSelector()`
+- `reopenPlateSelector()` sets `showPlateSelector = true` when plates are non-empty
+- `reopenPlateSelector()` is a no-op when `multiPlatePlates` is empty

--- a/docs/superpowers/specs/2026-04-21-f74-finer-scaling-design.md
+++ b/docs/superpowers/specs/2026-04-21-f74-finer-scaling-design.md
@@ -1,0 +1,75 @@
+# F74: Finer Model Scaling — Design Spec
+
+**Date:** 2026-04-21
+**Feature:** 1% scale precision via continuous slider + editable text field
+
+---
+
+## Problem
+
+The scale slider uses `steps = 28` over the 0.1–3.0 range, giving ~10% per step. Users cannot set a precise percentage (e.g. 97%) to maximise build-plate usage for slightly-oversized models.
+
+---
+
+## Goal
+
+Allow exact percentage entry for model scale while keeping the drag-slider experience for quick rough adjustment.
+
+---
+
+## Design
+
+### Changes to `ScaleSection` in `MainActivity.kt`
+
+**1. Remove `steps` from all scale sliders**
+
+Remove `steps = 28` from the uniform slider and from each of the X/Y/Z axis sliders. The slider becomes continuous — any value between 10% and 300% is reachable by dragging.
+
+**2. Replace read-only label with editable `OutlinedTextField`**
+
+Replace `Text("Scale: $pct")` (and the per-axis `Text("$axis: $pct")` labels) with a compact `OutlinedTextField` showing the integer percentage. Layout: label on the left, text field on the right, slider below spanning full width.
+
+Behaviour:
+- Field shows integer percentage (e.g. `"150"`)
+- `keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number, imeAction = ImeAction.Done)`
+- `keyboardActions = KeyboardActions(onDone = { ... })` — commits the value, clamps to 10–300, calls `onScaleChange`, closes keyboard
+- `onValueChange` updates local draft string; only calls `onScaleChange` on commit (Done / focus loss)
+- Invalid input (empty, non-numeric, out of range) is silently clamped to 10 or 300 on commit
+- Width: `80.dp` fixed; no suffix label needed (context is obvious)
+
+**3. Uniform mode**
+
+```
+Scale: [150] (OutlinedTextField, 80dp wide)
+[────────────────────────── slider ──────────────────────────]
+```
+
+Slider and text field stay in sync: dragging updates the field live; committing the field snaps the slider thumb.
+
+**4. Non-uniform mode**
+
+Same pattern for each of X, Y, Z — label + field on one row, slider below.
+
+---
+
+## State
+
+`uniformValue` (existing `mutableFloatStateOf`) drives both slider and field. A new `var uniformText by remember(uniformValue) { mutableStateOf("%.0f".format(uniformValue * 100)) }` holds the in-progress text. On slider drag, `uniformText` is updated alongside `uniformValue`. On field commit, `uniformValue` is updated from the parsed text.
+
+Same pattern for non-uniform axes (local draft strings per axis).
+
+---
+
+## Files
+
+| File | Change |
+|---|---|
+| `app/src/main/java/com/u1/slicer/MainActivity.kt` | Modify `ScaleSection`: remove `steps`, replace Text labels with OutlinedTextField |
+
+No ViewModel changes. No new files. No tests required (pure UI composition change with no logic).
+
+---
+
+## Scope
+
+Uniform and non-uniform scale only. Rotation sliders are unchanged (degree precision is fine with the existing slider).


### PR DESCRIPTION
## Summary
- land the F73 multi-plate / plate-switch hardening stack
- land the F74 finer scaling UI improvements
- land the camera wake keepalive and LED sync fixes
- add Bambu pipeline artifact inspection/export from the model info dialog
- include review follow-up fixes for slice cancellation race, export launcher race, and test/doc updates

## Verification
- full JVM unit suite passed
- full connected Android test suite passed earlier on Pixel 8a
- manual Pixel 8a smoke test passed for the export dialog/actions
- follow-up review marked the branch ready to merge

## Notes
- export actions were consolidated into the existing model info dialog
- export outputs are the sanitized 3MF and sanitized + U1 profile embedded 3MF
