### PR TITLE
docs(B95): log plate 9 paint-state-drop + add diagnostic repro test

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,6 +4,18 @@ Open bugs, features, and investigations. Everything else is done — see git log
 
 ## Open Bugs
 
+### B95: Buzz plate 9 paint state 8 dropped by slicer — only T0 in G-code (GitHub #102)
+- **Symptom**: On v1.6.10, Buzz Lightyear plate 9 Prepare shows 2 distinct colours correctly (peach #FFD6C1 + white #FFFFFF per the B90 detection fix), but the sliced G-code contains only `T0` (3 tool changes across 605 layers) with no `T1`/`T2`/`T3`. Slice summary reports a single extruder; G-code 3D preview renders the whole model in the renderer's default slot-0 colour (orange) because no user colour is assigned to physical slot 0 for this plate.
+- **Distinct from B92**: B92 was about Prepare ↔ Preview palette alignment on plates where OrcaSlicer's print order disagreed with detectedColors. Plate 9's slicer never emits the paint state as a tool change, so this is a paint-segmentation / embedder issue upstream of any palette alignment.
+- **Reproduction**: `DC15BuzzRepro.dc15_buzzPlate9_diagnosticDump` — loads Buzz, selects plate 9, slices, dumps tool counts + G-code header. On current main: `T0=3 T1=0 T2=0 T3=0`. The embedder's `filament_colour` header is `#000000;#0086D6` (Bambu filaments 1+2) instead of `#FFD6C1;#FFFFFF` (the actually-used filaments 8+10) — same embedder smell flagged in #96, but here it plausibly correlates with the slicer's inability to emit paint-state 8 as a tool change (paint state index > compact embedded profile size).
+- **Root-cause hypotheses** (not yet verified):
+  1. `BambuSanitizer` rewrites object `extruder` attributes but doesn't consistently compact `paint_color` attributes to match — state 8 stays as "8" in the sanitized 3MF, and native `multi_material_segmentation_by_painting()` silently drops it against the 2-entry compact `filament_colour` array.
+  2. `computeEmbedTargetCount` under-sizes `filament_colour` for this shape (object default + single high-index paint state with total 2 distinct detected colours) — a targeted version of the B48 fix.
+  3. Native paint segmentation discards paint states beyond `num_facets_states = filament_colour.size()+1` on startup without expanding.
+- **Not affected**: Plate 1 (4-colour object-extruder) emits all 4 tools; plate 8 (object 10 + paint state 3, lower-indexed) emits T0+T3 correctly after v1.6.10.
+- **Test file**: `Buzz_Multipart_3MF_Bambu.3mf` plate 9 (already in `app/src/androidTest/assets/`).
+- **Source**: Discord user DC15, 2026-04-23
+
 ### B94: User drag-to-move object position lost after slicing (GitHub #99) — REGRESSION GUARD v1.6.10
 - **Symptom (reported)**: User drags object to a new bed position on Prepare → slice → Preview shows the object back at the default (front-centre) position. Reproduces on single-object Spiderman file. Wipe tower IS preserved.
 - **Investigation**: New instrumented test `spiderman_dragToRight_preservesPositionThroughSlice` calls `applyPlacementPositions(dragPositions)` directly, slices, and parses the G-code's X extents. Passes on Pixel 8a — the ViewModel → native `setModelInstances(custom)` path correctly propagates the drag offset through re-embed and slice, and the G-code reflects the drag destination (right edge ~270mm for dragX chosen to push the bottom-left to the far-right edge).

--- a/app/src/androidTest/java/com/u1/slicer/DC15BuzzRepro.kt
+++ b/app/src/androidTest/java/com/u1/slicer/DC15BuzzRepro.kt
@@ -1,0 +1,347 @@
+package com.u1.slicer
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.u1.slicer.data.ExtruderPreset
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * Reproduces DC15's reported v1.6.10 issues for triage — not a pass/fail assertion,
+ * a diagnostic dump.
+ *
+ * DC15's device state (from Discord screenshots):
+ *   E1 = PINK  (#FF69B4 used as proxy; true hex unknown)
+ *   E2 = BLUE  (#0000FF)
+ *   E3 = WHITE (#FFFFFF)
+ *   E4 = BLACK (#000000 — inferred from plate 9 Prepare Setup "E4 ●")
+ *
+ * Plate 8 report: Slice summary shows E1 (pink) for the painted stripes (correct),
+ * but the G-code 3D viewer renders the stripes BLUE (E2's loaded filament).
+ *
+ * Plate 9 report: Prepare shows 2 distinct colours (peach+white painted, per our
+ * B90 investigation); after slicing only ONE extruder appears in the summary (E3)
+ * and the 3D viewer renders the whole model ORANGE (GcodeRenderer's default slot 0
+ * colour when no override fires).
+ *
+ * This test dumps everything needed to distinguish:
+ *   - Is semmColorPermutation actually being set? (would land in G-code remap)
+ *   - Is slicerColorOrder being computed for DC15's preset state?
+ *   - Which T-indices are actually present in the sliced G-code?
+ *   - What does normalizeGcodePreviewColors output for this state?
+ */
+@RunWith(AndroidJUnit4::class)
+class DC15BuzzRepro {
+
+    private val targetContext get() = InstrumentationRegistry.getInstrumentation().targetContext
+    private val assetContext get() = InstrumentationRegistry.getInstrumentation().context
+
+    private fun copyAssetToCache(assetName: String): File {
+        val outFile = File(targetContext.cacheDir, assetName.replace("/", "_"))
+        assetContext.assets.open(assetName).use { input ->
+            outFile.outputStream().use { output -> input.copyTo(output) }
+        }
+        return outFile
+    }
+
+    private fun waitUntil(label: String, timeoutMs: Long = 60_000L, condition: () -> Boolean) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (condition()) return
+            Thread.sleep(100)
+        }
+        throw AssertionError("Timed out waiting for $label")
+    }
+
+    @Test
+    fun dc15_buzzPlate8_diagnosticDump() {
+        val application = targetContext.applicationContext as U1SlicerApplication
+        val settingsRepo = application.container.settingsRepository
+        val viewModel = SlicerViewModel(application)
+
+        // Set DC15-like presets.
+        runBlocking {
+            settingsRepo.saveExtruderPresets(listOf(
+                ExtruderPreset(index = 0, color = "#FF69B4"),  // E1 PINK
+                ExtruderPreset(index = 1, color = "#0000FF"),  // E2 BLUE
+                ExtruderPreset(index = 2, color = "#FFFFFF"),  // E3 WHITE
+                ExtruderPreset(index = 3, color = "#000000"),  // E4 BLACK
+            ))
+        }
+        // Give DataStore a moment to propagate.
+        Thread.sleep(1_000)
+
+        val modelFile = copyAssetToCache("Buzz_Multipart_3MF_Bambu.3mf")
+        try {
+            viewModel.loadModelFromFile(modelFile)
+
+            waitUntil("buzz plate selector visible", timeoutMs = 240_000L) {
+                viewModel.showPlateSelector.value ||
+                    viewModel.state.value is SlicerViewModel.SlicerState.Error
+            }
+            (viewModel.state.value as? SlicerViewModel.SlicerState.Error)?.let {
+                throw AssertionError("Buzz load failed: ${it.message}")
+            }
+
+            viewModel.selectPlate(8)
+            waitUntil("plate 8 loaded", timeoutMs = 120_000L) {
+                viewModel.state.value is SlicerViewModel.SlicerState.ModelLoaded &&
+                    viewModel.colorMapping.value != null
+            }
+            Thread.sleep(600)
+
+            val info = viewModel.threeMfInfo.value!!
+            val colorMapping = viewModel.colorMapping.value!!
+            val extruderColors = viewModel.activeExtruderColors.value.toList()
+            val slicerColorOrder = viewModel.slicerColorOrder.value
+            val semmColorPermutation = viewModel.semmColorPermutationFlow.value
+
+            android.util.Log.i("DC15Repro",
+                "PLATE 8 STATE\n" +
+                "  detectedColors=${info.detectedColors}\n" +
+                "  usedExtruderIndices=${info.usedExtruderIndices}\n" +
+                "  objectExtruderMap=${info.objectExtruderMap}\n" +
+                "  colorMapping=$colorMapping\n" +
+                "  activeExtruderColors=$extruderColors\n" +
+                "  slicerColorOrder=$slicerColorOrder\n" +
+                "  semmColorPermutation=$semmColorPermutation"
+            )
+
+            viewModel.startSlicing()
+            waitUntil("slice complete", timeoutMs = 300_000L) {
+                viewModel.state.value is SlicerViewModel.SlicerState.SliceComplete ||
+                    viewModel.state.value is SlicerViewModel.SlicerState.Error
+            }
+            (viewModel.state.value as? SlicerViewModel.SlicerState.Error)?.let {
+                throw AssertionError("Slice failed: ${it.message}")
+            }
+
+            val result = (viewModel.state.value as SlicerViewModel.SlicerState.SliceComplete).result
+            val gcode = File(result.gcodePath).readText()
+            val lines = gcode.lines()
+            val toolCounts = (0..3).map { t -> lines.count { it.trim() == "T$t" } }
+            val filamentColourHeader = lines.firstOrNull { it.startsWith("; filament_colour") }
+
+            val previewColors = normalizeGcodePreviewColors(
+                extruderColors = extruderColors,
+                colorMapping = colorMapping,
+                semmColorPermutation = semmColorPermutation,
+                slicerColorOrder = slicerColorOrder
+            )
+
+            android.util.Log.i("DC15Repro",
+                "PLATE 8 G-CODE + PREVIEW\n" +
+                "  T0=${toolCounts[0]} T1=${toolCounts[1]} T2=${toolCounts[2]} T3=${toolCounts[3]}\n" +
+                "  filament_colour_header=$filamentColourHeader\n" +
+                "  previewColors=$previewColors\n" +
+                "  => T0 renders=${previewColors.getOrNull(0)}\n" +
+                "  => T1 renders=${previewColors.getOrNull(1)}\n" +
+                "  => T2 renders=${previewColors.getOrNull(2)}\n" +
+                "  => T3 renders=${previewColors.getOrNull(3)}"
+            )
+        } finally {
+            viewModel.clearModel()
+            modelFile.delete()
+            // Restore default presets so other tests aren't polluted.
+            runBlocking {
+                settingsRepo.saveExtruderPresets(com.u1.slicer.data.defaultExtruderPresets())
+            }
+        }
+    }
+
+    /**
+     * Force DC15's exact colorMapping = [0, 2] (Color 1 brown → E1 PINK,
+     * Color 2 white → E3 WHITE) via applyMultiColorAssignments, bypassing
+     * auto-match. This matches DC15's v1.6.10 screenshot exactly.
+     */
+    @Test
+    fun dc15_buzzPlate8_forcedMappingDump() {
+        val application = targetContext.applicationContext as U1SlicerApplication
+        val settingsRepo = application.container.settingsRepository
+        val viewModel = SlicerViewModel(application)
+
+        runBlocking {
+            settingsRepo.saveExtruderPresets(listOf(
+                ExtruderPreset(index = 0, color = "#FF69B4"),
+                ExtruderPreset(index = 1, color = "#0000FF"),
+                ExtruderPreset(index = 2, color = "#FFFFFF"),
+                ExtruderPreset(index = 3, color = "#000000"),
+            ))
+        }
+        Thread.sleep(1_000)
+
+        val modelFile = copyAssetToCache("Buzz_Multipart_3MF_Bambu.3mf")
+        try {
+            viewModel.loadModelFromFile(modelFile)
+
+            waitUntil("buzz plate selector visible", timeoutMs = 240_000L) {
+                viewModel.showPlateSelector.value ||
+                    viewModel.state.value is SlicerViewModel.SlicerState.Error
+            }
+            (viewModel.state.value as? SlicerViewModel.SlicerState.Error)?.let {
+                throw AssertionError("Buzz load failed: ${it.message}")
+            }
+
+            viewModel.selectPlate(8)
+            waitUntil("plate 8 loaded", timeoutMs = 120_000L) {
+                viewModel.state.value is SlicerViewModel.SlicerState.ModelLoaded &&
+                    viewModel.colorMapping.value != null
+            }
+            Thread.sleep(600)
+
+            // Force DC15's mapping: Color 1 (brown) → E1 PINK (slot 0), Color 2 (white) → E3 WHITE (slot 2)
+            val dc15Mapping = listOf(0, 2)
+            val presets = viewModel.extruderPresets.value
+            val filaments = viewModel.filaments.value
+            viewModel.applyMultiColorAssignments(dc15Mapping, presets, filaments)
+            Thread.sleep(1_000)
+
+            val info = viewModel.threeMfInfo.value!!
+            val colorMapping = viewModel.colorMapping.value!!
+            val extruderColors = viewModel.activeExtruderColors.value.toList()
+            val slicerColorOrder = viewModel.slicerColorOrder.value
+            val semmColorPermutation = viewModel.semmColorPermutationFlow.value
+
+            android.util.Log.i("DC15Repro",
+                "PLATE 8 FORCED-MAPPING STATE\n" +
+                "  detectedColors=${info.detectedColors}\n" +
+                "  usedExtruderIndices=${info.usedExtruderIndices}\n" +
+                "  objectExtruderMap=${info.objectExtruderMap}\n" +
+                "  colorMapping=$colorMapping\n" +
+                "  activeExtruderColors=$extruderColors\n" +
+                "  slicerColorOrder=$slicerColorOrder\n" +
+                "  semmColorPermutation=$semmColorPermutation"
+            )
+
+            viewModel.startSlicing()
+            waitUntil("slice complete", timeoutMs = 300_000L) {
+                viewModel.state.value is SlicerViewModel.SlicerState.SliceComplete ||
+                    viewModel.state.value is SlicerViewModel.SlicerState.Error
+            }
+            (viewModel.state.value as? SlicerViewModel.SlicerState.Error)?.let {
+                throw AssertionError("Slice failed: ${it.message}")
+            }
+
+            val result = (viewModel.state.value as SlicerViewModel.SlicerState.SliceComplete).result
+            val gcode = File(result.gcodePath).readText()
+            val lines = gcode.lines()
+            val toolCounts = (0..3).map { t -> lines.count { it.trim() == "T$t" } }
+            val filamentColourHeader = lines.firstOrNull { it.startsWith("; filament_colour") }
+
+            val previewColors = normalizeGcodePreviewColors(
+                extruderColors = extruderColors,
+                colorMapping = colorMapping,
+                semmColorPermutation = semmColorPermutation,
+                slicerColorOrder = slicerColorOrder
+            )
+
+            android.util.Log.i("DC15Repro",
+                "PLATE 8 FORCED-MAPPING G-CODE + PREVIEW\n" +
+                "  T0=${toolCounts[0]} T1=${toolCounts[1]} T2=${toolCounts[2]} T3=${toolCounts[3]}\n" +
+                "  filament_colour_header=$filamentColourHeader\n" +
+                "  previewColors=$previewColors\n" +
+                "  => T0 renders=${previewColors.getOrNull(0)}\n" +
+                "  => T1 renders=${previewColors.getOrNull(1)}\n" +
+                "  => T2 renders=${previewColors.getOrNull(2)}\n" +
+                "  => T3 renders=${previewColors.getOrNull(3)}"
+            )
+        } finally {
+            viewModel.clearModel()
+            modelFile.delete()
+            runBlocking {
+                settingsRepo.saveExtruderPresets(com.u1.slicer.data.defaultExtruderPresets())
+            }
+        }
+    }
+
+    @Test
+    fun dc15_buzzPlate9_diagnosticDump() {
+        val application = targetContext.applicationContext as U1SlicerApplication
+        val settingsRepo = application.container.settingsRepository
+        val viewModel = SlicerViewModel(application)
+
+        runBlocking {
+            settingsRepo.saveExtruderPresets(listOf(
+                ExtruderPreset(index = 0, color = "#FF69B4"),
+                ExtruderPreset(index = 1, color = "#0000FF"),
+                ExtruderPreset(index = 2, color = "#FFFFFF"),
+                ExtruderPreset(index = 3, color = "#000000"),
+            ))
+        }
+        Thread.sleep(1_000)
+
+        val modelFile = copyAssetToCache("Buzz_Multipart_3MF_Bambu.3mf")
+        try {
+            viewModel.loadModelFromFile(modelFile)
+
+            waitUntil("buzz plate selector visible", timeoutMs = 240_000L) {
+                viewModel.showPlateSelector.value ||
+                    viewModel.state.value is SlicerViewModel.SlicerState.Error
+            }
+            (viewModel.state.value as? SlicerViewModel.SlicerState.Error)?.let {
+                throw AssertionError("Buzz load failed: ${it.message}")
+            }
+
+            viewModel.selectPlate(9)
+            waitUntil("plate 9 loaded", timeoutMs = 120_000L) {
+                viewModel.state.value is SlicerViewModel.SlicerState.ModelLoaded &&
+                    viewModel.colorMapping.value != null
+            }
+            Thread.sleep(600)
+
+            val info = viewModel.threeMfInfo.value!!
+            val colorMapping = viewModel.colorMapping.value!!
+            val extruderColors = viewModel.activeExtruderColors.value.toList()
+            val slicerColorOrder = viewModel.slicerColorOrder.value
+            val semmColorPermutation = viewModel.semmColorPermutationFlow.value
+
+            android.util.Log.i("DC15Repro",
+                "PLATE 9 STATE\n" +
+                "  detectedColors=${info.detectedColors}\n" +
+                "  usedExtruderIndices=${info.usedExtruderIndices}\n" +
+                "  objectExtruderMap=${info.objectExtruderMap}\n" +
+                "  colorMapping=$colorMapping\n" +
+                "  activeExtruderColors=$extruderColors\n" +
+                "  slicerColorOrder=$slicerColorOrder\n" +
+                "  semmColorPermutation=$semmColorPermutation"
+            )
+
+            viewModel.startSlicing()
+            waitUntil("slice complete", timeoutMs = 600_000L) {
+                viewModel.state.value is SlicerViewModel.SlicerState.SliceComplete ||
+                    viewModel.state.value is SlicerViewModel.SlicerState.Error
+            }
+            (viewModel.state.value as? SlicerViewModel.SlicerState.Error)?.let {
+                throw AssertionError("Slice failed: ${it.message}")
+            }
+
+            val result = (viewModel.state.value as SlicerViewModel.SlicerState.SliceComplete).result
+            val gcode = File(result.gcodePath).readText()
+            val lines = gcode.lines()
+            val toolCounts = (0..3).map { t -> lines.count { it.trim() == "T$t" } }
+            val filamentColourHeader = lines.firstOrNull { it.startsWith("; filament_colour") }
+
+            val previewColors = normalizeGcodePreviewColors(
+                extruderColors = extruderColors,
+                colorMapping = colorMapping,
+                semmColorPermutation = semmColorPermutation,
+                slicerColorOrder = slicerColorOrder
+            )
+
+            android.util.Log.i("DC15Repro",
+                "PLATE 9 G-CODE + PREVIEW\n" +
+                "  T0=${toolCounts[0]} T1=${toolCounts[1]} T2=${toolCounts[2]} T3=${toolCounts[3]}\n" +
+                "  filament_colour_header=$filamentColourHeader\n" +
+                "  previewColors=$previewColors"
+            )
+        } finally {
+            viewModel.clearModel()
+            modelFile.delete()
+            runBlocking {
+                settingsRepo.saveExtruderPresets(com.u1.slicer.data.defaultExtruderPresets())
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Logs **B95** in BACKLOG.md — Buzz Lightyear plate 9 slices to a single-extruder G-code on v1.6.10 despite Prepare showing 2 distinct colour regions. Distinct from B92; the paint state is being dropped by slicer/embedder before tool assignment.
- Adds `DC15BuzzRepro.kt` with three diagnostic tests: plate 8 auto-map dump, plate 8 forced-mapping dump (matches DC15's reported `colorMapping = [0, 2]`), and plate 9 dump. Plate 9 reliably reproduces `T0=3 T1=0 T2=0 T3=0`. Plate 8 forced-mapping shows CORRECT Preview palette (T0→white, T2→pink) on Pixel 8a under v1.6.10 — couldn't reproduce DC15's reported blue-stripes symptom there.
- No production code changes.

Refs #102