### PR TITLE
docs: B58 incidental-fix note + README current-release bump (v1.6.8 → v1.6.13)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -190,12 +190,13 @@ Open bugs, features, and investigations. Everything else is done — see git log
 - Fix: post-slice G-code header patch — `fixFilamentTypeHeader()` replaces `; filament_type = PLA` with actual per-extruder material types from extruder presets
 - **Source**: Discord user Jon (2026-04-14)
 
-### B58: SEMM painted model preview colours don't match sliced output or desktop OrcaSlicer (GitHub #60)
+### B58: SEMM painted model preview colours don't match sliced output or desktop OrcaSlicer (GitHub #60) — likely fixed v1.6.13, needs E2E confirmation
 - For `colored_3DBenchy (1).3mf` (4-colour SEMM), the Prepare preview, G-code preview, and desktop OrcaSlicer all show different colours
 - **Prepare screen**: Only 2 colour chips shown; model renders mostly white/gray — 2 of 4 paint zones missing
 - **G-code preview**: More colours visible in toolpath render but different distribution from desktop reference
 - Not a slicing correctness issue (all 4 extruders active in G-code), but gives user a misleading picture
 - **Affects**: All SEMM painted models (`hasPaintData=true`)
+- **2026-04-23 v1.6.13 manual check**: post-decoder, `colored_3DBenchy (1).3mf` reports `colors=4, mapping=[0, 1, 2, 3]`, all 4 colour chips visible (Color 1 blue, Color 2 red, Color 3 yellow, Color 4 white) and the Prepare 3D mini-preview shows all 4 colours on the Benchy. Symptom appears resolved by the new `PaintColorDecoder` correctly identifying all paint states. Formal verification via the next E2E batch (Prepare colour-zone count + sliced G-code preview render comparison) before closing.
 - **When fixed**: restore CP TOOLCHANGE~27 assertion in the `colored_3DBenchy (1).3mf` E2E check (skill file + memory `e2e-testing.md`) — it was suppressed due to this bug
 
 ### B54: Modifier volumes rendered as solid geometry in Prepare preview (GitHub #55) — FIXED

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Native Android slicer for the **Snapmaker U1** 3D printer (270×270×270mm, 4 ex
 
 Built with Kotlin, Jetpack Compose, and OrcaSlicer's C++ engine via JNI — no server required, everything runs on-device.
 
-Current release: `v1.6.8` (`versionCode 252`)
+Current release: `v1.6.13` (`versionCode 258`)
 
 **This has been fully "vibe" coded using AI. A lot of effort has gone into adding as many unit, instrumented and manaual e2e tests as as possible which are run before every release, but use at your own risk.**
 


### PR DESCRIPTION
## Summary

Two docs-only catch-ups after the v1.6.12 + v1.6.13 ship:

1. **B58 BACKLOG annotation** — Manual check on Pixel 8a 2026-04-23: `colored_3DBenchy (1).3mf` (the canonical B58 reproducer) loads with `colors=4, mapping=[0, 1, 2, 3]`, all 4 colour chips render in Print Setup (Color 1 blue, Color 2 red, Color 3 yellow, Color 4 white), and the Prepare 3D mini-preview shows all 4 colours. The B58 symptom — "Only 2 colour chips shown; model renders mostly white/gray — 2 of 4 paint zones missing" — is no longer reproducing. Likely cause is the new `PaintColorDecoder` in v1.6.13 correctly identifying every paint state where the prior first-character heuristic was silently dropping bit-packed extended-encoding paint states. Annotation flips B58's BACKLOG line from open-bug formatting to "likely fixed v1.6.13, needs E2E confirmation".

2. **README current-release bump** — The README badge had been stale at `v1.6.8` (`versionCode 252`) for six releases. Bumped to `v1.6.13` (`versionCode 258`) to match the actual GitHub release.

## Follow-ups

When the next E2E batch covers `colored_3DBenchy (1).3mf` and the Prepare colour-zone count + sliced G-code preview render are both correct, B58 can be closed and the suppressed `CP TOOLCHANGE~27` assertion in the E2E skill file + `e2e-testing.md` memory can be restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)