### PR TITLE
Fix wrong nozzle on print-from-internal-memory + honest Upload-Only UX

### DIFF
--- a/.maestro/slice_3mf_singlecolour.yaml
+++ b/.maestro/slice_3mf_singlecolour.yaml
@@ -33,7 +33,7 @@ appId: com.u1.slicer.orca
 
 # Result shown
 - assertVisible: "layers"
-- assertVisible: "Map & Upload"
+- assertVisible: "Upload Only"
 - assertNotVisible: "Error"
 
 

--- a/.maestro/slice_multicolour.yaml
+++ b/.maestro/slice_multicolour.yaml
@@ -26,7 +26,7 @@ appId: com.u1.slicer.orca
     visible: "Slice Summary"
     timeout: 180000
 
-- assertVisible: "Map & Upload"
+- assertVisible: "Upload Only"
 - assertNotVisible: "Error"
 - assertNotVisible: "failed"
 

--- a/.maestro/slice_stl.yaml
+++ b/.maestro/slice_stl.yaml
@@ -39,7 +39,7 @@ appId: com.u1.slicer.orca
 # Result summary must show layer count and time estimate
 - assertVisible: "layers"
 - assertVisible: "Est. Time"
-- assertVisible: "Map & Upload"
+- assertVisible: "Upload Only"
 
 # No crash — check no error dialog is visible
 - assertNotVisible: "Error"

--- a/app/src/main/java/com/u1/slicer/MainActivity.kt
+++ b/app/src/main/java/com/u1/slicer/MainActivity.kt
@@ -817,6 +817,53 @@ class MainActivity : ComponentActivity() {
                         is CanonicalLookup.Present -> {
                             if (canonical != null && plateNarrowed != null) {
                                 val (narrowedList, plateFileIndices) = plateNarrowed
+                                when (pending.action) {
+                                    PendingMappingSend.Action.UploadOnly -> {
+                                        // Internal-memory wrong-nozzle fix (2026-06-03):
+                                        // send-to-hold ships the CANONICAL body and lets the
+                                        // printer's Filament Setup map it once. No in-app slot
+                                        // picker — its picks would double-remap (the body is
+                                        // already physical + the printer maps again → wrong
+                                        // nozzle). See gcode.sendRemapForAction KDoc.
+                                        com.u1.slicer.ui.UploadConfirmationDialog(
+                                            canonicalList = narrowedList,
+                                            plateFileIndices = plateFileIndices,
+                                            modelName = viewModel.modelFileName.value,
+                                            onConfirm = {
+                                                val sourceFile = java.io.File(pending.gcodePath)
+                                                val heldFile = java.io.File(
+                                                    sourceFile.parentFile,
+                                                    "${sourceFile.nameWithoutExtension}.remapped.${sourceFile.extension}"
+                                                )
+                                                pendingMappingSend = null
+                                                navigateTab(Routes.PRINTER)
+                                                sendActionScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+                                                    // Foreground service across the large-file
+                                                    // copy so the freezer can't kill it once
+                                                    // the app is backgrounded.
+                                                    LongOpService.start(toastContext, "Preparing G-code")
+                                                    val physical = try {
+                                                        com.u1.slicer.gcode.applyPrintTimeRemap(
+                                                            source = com.u1.slicer.gcode.CanonicalGcodePath.of(sourceFile),
+                                                            output = com.u1.slicer.gcode.PhysicalGcodePath.of(heldFile),
+                                                            colorMapping = com.u1.slicer.gcode.sendRemapForAction(
+                                                                uploadOnly = true,
+                                                                physicalMapping = emptyList(),
+                                                            ),
+                                                        )
+                                                    } finally {
+                                                        LongOpService.stop(toastContext)
+                                                    }
+                                                    val modelName = viewModel.modelFileName.value
+                                                    withContext(kotlinx.coroutines.Dispatchers.Main) {
+                                                        printerViewModel.sendUploadOnly(physical, modelName)
+                                                    }
+                                                }
+                                            },
+                                            onDismiss = { pendingMappingSend = null },
+                                        )
+                                    }
+                                    PendingMappingSend.Action.PrintAndUpload -> {
                                 // Phase 2.5 final: slices produce canonical
                                 // (file-filament-relative) T-indices. The
                                 // dialog now shows only the plate's
@@ -876,16 +923,11 @@ class MainActivity : ComponentActivity() {
                                             // can't kill it once the user backgrounds
                                             // the app; the upload step starts its own.
                                             LongOpService.start(toastContext, "Preparing G-code")
-                                            // Internal-memory wrong-nozzle fix (2026-06-03):
-                                            // Upload-Only ships the canonical body (empty
-                                            // mapping = verbatim copy) so the printer's
-                                            // Filament Setup maps it once. Map & Print runs
-                                            // verbatim via the API, so it keeps the physical
-                                            // remap. See gcode.sendRemapForAction KDoc.
-                                            val uploadOnly =
-                                                pending.action == PendingMappingSend.Action.UploadOnly
+                                            // Map & Print runs verbatim via the API, so its
+                                            // body must already be in physical-slot space —
+                                            // keep the physical remap. See sendRemapForAction.
                                             val sendMapping = com.u1.slicer.gcode.sendRemapForAction(
-                                                uploadOnly = uploadOnly,
+                                                uploadOnly = false,
                                                 physicalMapping = expanded,
                                             )
                                             val physical = try {
@@ -899,17 +941,14 @@ class MainActivity : ComponentActivity() {
                                             }
                                             val modelName = viewModel.modelFileName.value
                                             withContext(kotlinx.coroutines.Dispatchers.Main) {
-                                                when (pending.action) {
-                                                    PendingMappingSend.Action.PrintAndUpload ->
-                                                        printerViewModel.sendAndPrint(physical, modelName)
-                                                    PendingMappingSend.Action.UploadOnly ->
-                                                        printerViewModel.sendUploadOnly(physical, modelName)
-                                                }
+                                                printerViewModel.sendAndPrint(physical, modelName)
                                             }
                                         }
                                     },
                                     onDismiss = { pendingMappingSend = null }
                                 )
+                                    }
+                                }
                             }
                         }
                         is CanonicalLookup.Absent -> {
@@ -2567,7 +2606,7 @@ fun SliceCompleteActionBar(
                     Icon(Icons.Default.CloudUpload, null, modifier = Modifier.size(16.dp))
                     Spacer(Modifier.width(4.dp))
                     Text(
-                        "Map & Upload",
+                        "Upload Only",
                         fontWeight = FontWeight.Bold,
                         fontSize = 13.sp,
                         maxLines = 1,

--- a/app/src/main/java/com/u1/slicer/MainActivity.kt
+++ b/app/src/main/java/com/u1/slicer/MainActivity.kt
@@ -829,6 +829,10 @@ class MainActivity : ComponentActivity() {
                                             canonicalList = narrowedList,
                                             plateFileIndices = plateFileIndices,
                                             modelName = viewModel.modelFileName.value,
+                                            // Show the sliced-with material (slot preset wins
+                                            // over file-declared), matching the Per-Extruder
+                                            // summary — e.g. PETG, not the file's PLA.
+                                            slicedMaterials = viewModel.sliceTimeMaterials(canonical, currentMapping),
                                             onConfirm = {
                                                 val sourceFile = java.io.File(pending.gcodePath)
                                                 val heldFile = java.io.File(

--- a/app/src/main/java/com/u1/slicer/MainActivity.kt
+++ b/app/src/main/java/com/u1/slicer/MainActivity.kt
@@ -876,11 +876,23 @@ class MainActivity : ComponentActivity() {
                                             // can't kill it once the user backgrounds
                                             // the app; the upload step starts its own.
                                             LongOpService.start(toastContext, "Preparing G-code")
+                                            // Internal-memory wrong-nozzle fix (2026-06-03):
+                                            // Upload-Only ships the canonical body (empty
+                                            // mapping = verbatim copy) so the printer's
+                                            // Filament Setup maps it once. Map & Print runs
+                                            // verbatim via the API, so it keeps the physical
+                                            // remap. See gcode.sendRemapForAction KDoc.
+                                            val uploadOnly =
+                                                pending.action == PendingMappingSend.Action.UploadOnly
+                                            val sendMapping = com.u1.slicer.gcode.sendRemapForAction(
+                                                uploadOnly = uploadOnly,
+                                                physicalMapping = expanded,
+                                            )
                                             val physical = try {
                                                 com.u1.slicer.gcode.applyPrintTimeRemap(
                                                     source = com.u1.slicer.gcode.CanonicalGcodePath.of(sourceFile),
                                                     output = com.u1.slicer.gcode.PhysicalGcodePath.of(remappedFile),
-                                                    colorMapping = expanded,
+                                                    colorMapping = sendMapping,
                                                 )
                                             } finally {
                                                 LongOpService.stop(toastContext)

--- a/app/src/main/java/com/u1/slicer/gcode/PrintTimeRemap.kt
+++ b/app/src/main/java/com/u1/slicer/gcode/PrintTimeRemap.kt
@@ -167,3 +167,26 @@ fun applyPrintTimeRemap(
     applyPrintTimeRemap(source.absolutePath, output.absolutePath, colorMapping)
     return output
 }
+
+/**
+ * Internal-memory wrong-nozzle fix (2026-06-03) — chooses the [colorMapping]
+ * fed to [applyPrintTimeRemap] based on how the file will be started.
+ *
+ * The physical T-index remap is only correct for a verbatim API print
+ * (Map & Print). When a file is uploaded to hold and later started from the
+ * printer's own internal memory, the printer applies its Filament Setup
+ * (canonical→physical) mapping to the body. If the body is already in
+ * physical-slot space, the two maps compose → double remap → the first
+ * colour prints on the wrong nozzle.
+ *
+ * So for the Upload-Only / send-to-hold path we return an EMPTY mapping
+ * (verbatim copy = canonical body) and let the printer map once via Filament
+ * Setup. Map & Print returns the resolved [physicalMapping] so its body is
+ * print-ready for the verbatim API start.
+ *
+ * @param uploadOnly true for the send-to-hold / Upload-Only action.
+ * @param physicalMapping the resolved canonical-fileIndex → physical-slot
+ *   mapping (used only for Map & Print).
+ */
+fun sendRemapForAction(uploadOnly: Boolean, physicalMapping: List<Int>): List<Int> =
+    if (uploadOnly) emptyList() else physicalMapping

--- a/app/src/main/java/com/u1/slicer/ui/FilamentMappingDialog.kt
+++ b/app/src/main/java/com/u1/slicer/ui/FilamentMappingDialog.kt
@@ -466,12 +466,18 @@ internal fun autoSuggestMapping(
  * @param plateFileIndices When plate-narrowed, the canonical fileIdx per row
  *   (for "Filament N" labels matching Prepare); null → positional.
  * @param modelName Shown as the sheet subtitle.
+ * @param slicedMaterials Resolved per-canonical-fileIndex material the G-code
+ *   was actually sliced with (slot presets / Prepare overrides win over the
+ *   file-declared material). Indexed by canonical fileIndex. When present it is
+ *   shown instead of the file-declared `entry.materialType`, so the sheet
+ *   matches the Per-Extruder slice summary (e.g. PETG, not the file's PLA).
  */
 @Composable
 fun UploadConfirmationDialog(
     canonicalList: CanonicalFilamentList,
     plateFileIndices: List<Int>? = null,
     modelName: String? = null,
+    slicedMaterials: List<String>? = null,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -527,7 +533,12 @@ fun UploadConfirmationDialog(
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
                                 Text(
-                                    entry.materialType ?: "—",
+                                    // Show what the G-code was sliced with (slot
+                                    // preset / override wins), matching the
+                                    // Per-Extruder summary; fall back to the
+                                    // file-declared material only if unresolved.
+                                    slicedMaterials?.getOrNull(displayFileIndex)
+                                        ?: entry.materialType ?: "—",
                                     style = MaterialTheme.typography.bodyMedium,
                                     color = MaterialTheme.colorScheme.onSurface,
                                 )

--- a/app/src/main/java/com/u1/slicer/ui/FilamentMappingDialog.kt
+++ b/app/src/main/java/com/u1/slicer/ui/FilamentMappingDialog.kt
@@ -455,3 +455,108 @@ internal fun autoSuggestMapping(
 ): List<Int> = canonicalList.filaments.map { entry ->
     findClosestExtruder(entry.color, extruderPresets)?.index ?: 0
 }
+
+/**
+ * Upload-Only confirmation sheet (2026-06-03). The send-to-hold path ships
+ * the CANONICAL G-code body and lets the printer's Filament Setup map it, so
+ * there is no in-app slot picker here — this read-only sheet just confirms
+ * the upload and tells the user the printer will ask for nozzle assignment.
+ *
+ * @param canonicalList The file's canonical filament list (colour + material).
+ * @param plateFileIndices When plate-narrowed, the canonical fileIdx per row
+ *   (for "Filament N" labels matching Prepare); null → positional.
+ * @param modelName Shown as the sheet subtitle.
+ */
+@Composable
+fun UploadConfirmationDialog(
+    canonicalList: CanonicalFilamentList,
+    plateFileIndices: List<Int>? = null,
+    modelName: String? = null,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Card(
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+        ) {
+            Column(modifier = Modifier.padding(20.dp)) {
+                Text(
+                    "Upload to printer",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+                if (!modelName.isNullOrBlank()) {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        modelName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Spacer(Modifier.height(12.dp))
+
+                LazyColumn(
+                    modifier = Modifier.heightIn(max = 320.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    itemsIndexed(canonicalList.filaments) { idx, entry ->
+                        val displayFileIndex = plateFileIndices?.getOrNull(idx) ?: idx
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(10.dp)
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(28.dp)
+                                    .clip(CircleShape)
+                                    .background(parseHexColor(entry.color))
+                                    .border(1.dp, MaterialTheme.colorScheme.outline, CircleShape)
+                            )
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    "Filament ${displayFileIndex + 1}",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                Text(
+                                    entry.materialType ?: "—",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(12.dp))
+                Surface(
+                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Text(
+                        "When you start this print on the printer, it will ask " +
+                            "you to assign each colour to a nozzle.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(10.dp),
+                    )
+                }
+
+                Spacer(Modifier.height(12.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = onDismiss) { Text("Cancel") }
+                    Spacer(Modifier.width(8.dp))
+                    Button(onClick = onConfirm) { Text("Upload") }
+                }
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/u1/slicer/MapAndPrintScopeRegressionTest.kt
+++ b/app/src/test/java/com/u1/slicer/MapAndPrintScopeRegressionTest.kt
@@ -135,9 +135,10 @@ class MapAndPrintScopeRegressionTest {
             "MainActivity.kt no longer contains `pendingMappingSend?.let` block."
         }
         // Scan the rest of the file for `sendActionScope.launch(`. The gate
-        // contains exactly two such launches in the current shape (the
-        // CanonicalLookup.Present onConfirm path + the CanonicalLookup.Absent
-        // fallback path); both must use the hoisted scope.
+        // contains three such launches in the current shape (the
+        // CanonicalLookup.Present branch splits into UploadOnly + PrintAndUpload
+        // onConfirm paths, plus the CanonicalLookup.Absent fallback path); all
+        // must use the hoisted scope.
         val afterGate = src.substring(gateIdx)
         val sendActionLaunches = Regex("""sendActionScope\s*\.launch\s*\(""")
             .findAll(afterGate)

--- a/app/src/test/java/com/u1/slicer/gcode/CanonicalExportMappingTest.kt
+++ b/app/src/test/java/com/u1/slicer/gcode/CanonicalExportMappingTest.kt
@@ -3,6 +3,7 @@ package com.u1.slicer.gcode
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Test
+import java.io.File
 
 /**
  * Phase 2 (2026-04-28) — covers `resolveCanonicalExportMapping`, the
@@ -261,5 +262,57 @@ class CanonicalExportMappingTest {
             selectedExtruder = 0,
         )
         assertEquals(listOf(3, 0, 3), result)  // clamped to 0..3
+    }
+
+    // --- Internal-memory wrong-nozzle fix (2026-06-03) ---
+    // A held file printed from the printer's own internal memory has the
+    // printer's Filament Setup (canonical→physical) mapping applied to it.
+    // If the body was already remapped to physical slots at Send time, the
+    // two maps compose → double remap → first colour on the wrong nozzle
+    // (Discord: brown landed on nozzle 3 instead of 2). So Upload-Only must
+    // ship the CANONICAL body and let the printer map once. Map & Print runs
+    // verbatim via the API, so it keeps the physical remap.
+
+    @Test
+    fun sendRemap_uploadOnly_returnsEmptyMappingForCanonicalBody() {
+        // Empty mapping makes applyPrintTimeRemap emit a verbatim canonical
+        // copy — the body stays in canonical (slicer) tool order.
+        val result = sendRemapForAction(uploadOnly = true, physicalMapping = listOf(1, 2, 3, 0))
+        assertEquals(emptyList<Int>(), result)
+    }
+
+    @Test
+    fun sendRemap_printAndUpload_keepsPhysicalMapping() {
+        // Map & Print body must already be in physical-slot space (the API
+        // start runs it verbatim) — keep the resolved physical mapping.
+        val result = sendRemapForAction(uploadOnly = false, physicalMapping = listOf(1, 2, 3, 0))
+        assertEquals(listOf(1, 2, 3, 0), result)
+    }
+
+    @Test
+    fun uploadOnly_emptyMapping_preservesCanonicalToolIndices() {
+        // End-to-end of the Upload-Only path: a canonical body (first tool
+        // T0) survives verbatim so the printer's own mapping isn't applied
+        // on top of an already-remapped body.
+        val src = File.createTempFile("canonical", ".gcode")
+        val out = File.createTempFile("held", ".gcode")
+        val body = "T0\nG1 X1\nM104 T1 S200\nT1\nSM_PRINT_AUTO_FEED EXTRUDER=0\n"
+        src.writeText(body)
+        val mapping = sendRemapForAction(uploadOnly = true, physicalMapping = listOf(1, 2, 3, 0))
+        applyPrintTimeRemap(src.absolutePath, out.absolutePath, mapping)
+        assertEquals(body, out.readText())
+        src.delete(); out.delete()
+    }
+
+    @Test
+    fun printAndUpload_physicalMapping_rewritesToolIndices() {
+        // Contrast: Map & Print bakes the physical mapping into the body.
+        val src = File.createTempFile("canonical", ".gcode")
+        val out = File.createTempFile("print", ".gcode")
+        src.writeText("T0\nT1\n")
+        val mapping = sendRemapForAction(uploadOnly = false, physicalMapping = listOf(1, 0))
+        applyPrintTimeRemap(src.absolutePath, out.absolutePath, mapping)
+        assertEquals("T1\nT0\n", out.readText())
+        src.delete(); out.delete()
     }
 }

--- a/app/src/test/java/com/u1/slicer/ui/UploadOnlyUxTest.kt
+++ b/app/src/test/java/com/u1/slicer/ui/UploadOnlyUxTest.kt
@@ -1,0 +1,50 @@
+package com.u1.slicer.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Upload-Only UX (2026-06-03). Structural guard — the project has no Compose
+ * UI test harness. Asserts the send-to-hold path routes to the read-only
+ * UploadConfirmationDialog (not the slot picker) and the button is renamed.
+ *
+ * Spec: docs/superpowers/specs/2026-06-03-upload-only-ux-design.md
+ */
+class UploadOnlyUxTest {
+
+    private fun source(rel: String): String {
+        val f = listOf(File(rel), File("../$rel")).firstOrNull { it.exists() }
+            ?: error("$rel not found from ${File(".").absolutePath}")
+        return f.readText()
+    }
+
+    @Test
+    fun uploadConfirmationDialog_exists() {
+        val src = source("app/src/main/java/com/u1/slicer/ui/FilamentMappingDialog.kt")
+        assertTrue(
+            "UploadConfirmationDialog composable must exist",
+            src.contains("fun UploadConfirmationDialog(")
+        )
+    }
+
+    @Test
+    fun uploadOnlyAction_routesToConfirmationDialog() {
+        val src = source("app/src/main/java/com/u1/slicer/MainActivity.kt")
+        assertTrue(
+            "Upload Only must render UploadConfirmationDialog",
+            src.contains("UploadConfirmationDialog(")
+        )
+    }
+
+    @Test
+    fun outlinedSendButton_renamedToUploadOnly() {
+        val src = source("app/src/main/java/com/u1/slicer/MainActivity.kt")
+        assertTrue("Button must read \"Upload Only\"", src.contains("\"Upload Only\""))
+        assertFalse(
+            "Stale \"Map & Upload\" label must be gone",
+            src.contains("\"Map & Upload\"")
+        )
+    }
+}

--- a/app/src/test/java/com/u1/slicer/ui/UploadOnlyUxTest.kt
+++ b/app/src/test/java/com/u1/slicer/ui/UploadOnlyUxTest.kt
@@ -38,6 +38,52 @@ class UploadOnlyUxTest {
         )
     }
 
+    private fun uploadConfirmationDialogBody(): String {
+        val src = source("app/src/main/java/com/u1/slicer/ui/FilamentMappingDialog.kt")
+        val start = src.indexOf("fun UploadConfirmationDialog(")
+        require(start >= 0) { "UploadConfirmationDialog not found" }
+        val bodyStart = src.indexOf('{', src.indexOf(')', start))
+        var depth = 0
+        var i = bodyStart
+        while (i < src.length) {
+            when (src[i]) {
+                '{' -> depth++
+                '}' -> { depth--; if (depth == 0) return src.substring(bodyStart, i + 1) }
+            }
+            i++
+        }
+        error("UploadConfirmationDialog body not terminated")
+    }
+
+    @Test
+    fun uploadConfirmationDialog_showsSlicedMaterialNotFileDeclared() {
+        // Regression: the sheet must show the material the G-code was SLICED
+        // with (slot presets / overrides win — e.g. PETG), not the file-declared
+        // material (e.g. PLA), so it matches the Per-Extruder summary. Guards
+        // that the dialog consumes a resolved-materials param, not only
+        // entry.materialType.
+        val body = uploadConfirmationDialogBody()
+        assertTrue(
+            "UploadConfirmationDialog must display resolved sliced materials " +
+                "(slicedMaterials), not only file-declared entry.materialType",
+            body.contains("slicedMaterials")
+        )
+    }
+
+    @Test
+    fun uploadOnlyBranch_feedsResolvedSlicedMaterials() {
+        // The Upload Only branch must pass the resolved per-filament materials
+        // into the sheet so the displayed material matches the slice.
+        val src = source("app/src/main/java/com/u1/slicer/MainActivity.kt")
+        val callIdx = src.indexOf("UploadConfirmationDialog(")
+        require(callIdx >= 0) { "UploadConfirmationDialog call not found" }
+        val callBlock = src.substring(callIdx, minOf(callIdx + 1200, src.length))
+        assertTrue(
+            "Upload Only must pass slicedMaterials = viewModel.sliceTimeMaterials(...)",
+            callBlock.contains("slicedMaterials = viewModel.sliceTimeMaterials(")
+        )
+    }
+
     @Test
     fun outlinedSendButton_renamedToUploadOnly() {
         val src = source("app/src/main/java/com/u1/slicer/MainActivity.kt")

--- a/docs/superpowers/plans/2026-06-03-upload-only-ux.md
+++ b/docs/superpowers/plans/2026-06-03-upload-only-ux.md
@@ -1,0 +1,333 @@
+# Upload-Only UX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the misleading slot-picker on the send-to-hold path with an honest read-only upload confirmation sheet, and rename the button "Map & Upload" → "Upload Only".
+
+**Architecture:** The Fix-A mapping change is already committed (canonical body for Upload-Only via `sendRemapForAction`). This plan is UI only: a new read-only `UploadConfirmationDialog`, branching the post-tap dialog on `PendingMappingSend.action`, and the button rename. Map & Print is untouched.
+
+**Tech Stack:** Kotlin, Jetpack Compose, Material3. JVM unit tests (source-grep structural guard for Compose, per project convention).
+
+**Spec:** `docs/superpowers/specs/2026-06-03-upload-only-ux-design.md`
+
+---
+
+### Task 1: `UploadConfirmationDialog` composable
+
+**Files:**
+- Modify: `app/src/main/java/com/u1/slicer/ui/FilamentMappingDialog.kt` (add new composable at end of file; reuses the file-local `parseHexColor`)
+
+- [ ] **Step 1: Add the composable**
+
+Append to `FilamentMappingDialog.kt` (after the last function, before EOF):
+
+```kotlin
+/**
+ * Upload-Only confirmation sheet (2026-06-03). The send-to-hold path ships
+ * the CANONICAL G-code body and lets the printer's Filament Setup map it, so
+ * there is no in-app slot picker here — this read-only sheet just confirms
+ * the upload and tells the user the printer will ask for nozzle assignment.
+ *
+ * @param canonicalList  the file's canonical filament list (colour + material).
+ * @param plateFileIndices  when plate-narrowed, the canonical fileIdx per row
+ *   (for "Filament N" labels matching Prepare); null → positional.
+ * @param modelName  shown as the sheet subtitle.
+ */
+@Composable
+fun UploadConfirmationDialog(
+    canonicalList: CanonicalFilamentList,
+    plateFileIndices: List<Int>? = null,
+    modelName: String? = null,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Card(
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+        ) {
+            Column(modifier = Modifier.padding(20.dp)) {
+                Text(
+                    "Upload to printer",
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                )
+                if (!modelName.isNullOrBlank()) {
+                    Spacer(Modifier.height(2.dp))
+                    Text(
+                        modelName,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Spacer(Modifier.height(12.dp))
+
+                LazyColumn(
+                    modifier = Modifier.heightIn(max = 320.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    itemsIndexed(canonicalList.filaments) { idx, entry ->
+                        val displayFileIndex = plateFileIndices?.getOrNull(idx) ?: idx
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(10.dp)
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .size(28.dp)
+                                    .clip(CircleShape)
+                                    .background(parseHexColor(entry.color))
+                                    .border(1.dp, MaterialTheme.colorScheme.outline, CircleShape)
+                            )
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    "Filament ${displayFileIndex + 1}",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                                Text(
+                                    entry.materialType ?: "—",
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                )
+                            }
+                        }
+                    }
+                }
+
+                Spacer(Modifier.height(12.dp))
+                Surface(
+                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Text(
+                        "When you start this print on the printer, it will ask " +
+                            "you to assign each colour to a nozzle.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(10.dp),
+                    )
+                }
+
+                Spacer(Modifier.height(12.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    TextButton(onClick = onDismiss) { Text("Cancel") }
+                    Spacer(Modifier.width(8.dp))
+                    Button(onClick = onConfirm) { Text("Upload") }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `./gradlew assembleDebug --no-daemon`
+Expected: BUILD SUCCESSFUL (no unresolved `parseHexColor` / import errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/src/main/java/com/u1/slicer/ui/FilamentMappingDialog.kt
+git commit -m "feat: UploadConfirmationDialog read-only send-to-hold sheet"
+```
+
+---
+
+### Task 2: Route Upload-Only to the new sheet + rename button
+
+**Files:**
+- Modify: `app/src/main/java/com/u1/slicer/MainActivity.kt` — Present-branch dialog (~L829-901), Upload-Only confirm handler, button label (~L2570)
+
+- [ ] **Step 1: Branch the Present-path dialog on action**
+
+In the `CanonicalLookup.Present` branch (the block that currently renders `FilamentMappingDialog` unconditionally at ~L829), wrap it:
+
+```kotlin
+when (pending.action) {
+    PendingMappingSend.Action.UploadOnly -> {
+        com.u1.slicer.ui.UploadConfirmationDialog(
+            canonicalList = narrowedList,
+            plateFileIndices = plateFileIndices,
+            modelName = viewModel.modelFileName.value,
+            onConfirm = {
+                val sourceFile = java.io.File(pending.gcodePath)
+                val heldFile = java.io.File(
+                    sourceFile.parentFile,
+                    "${sourceFile.nameWithoutExtension}.remapped.${sourceFile.extension}"
+                )
+                pendingMappingSend = null
+                navigateTab(Routes.PRINTER)
+                sendActionScope.launch(kotlinx.coroutines.Dispatchers.IO) {
+                    LongOpService.start(toastContext, "Preparing G-code")
+                    val physical = try {
+                        com.u1.slicer.gcode.applyPrintTimeRemap(
+                            source = com.u1.slicer.gcode.CanonicalGcodePath.of(sourceFile),
+                            output = com.u1.slicer.gcode.PhysicalGcodePath.of(heldFile),
+                            // Canonical body — printer maps held files via Filament Setup.
+                            colorMapping = com.u1.slicer.gcode.sendRemapForAction(
+                                uploadOnly = true, physicalMapping = emptyList(),
+                            ),
+                        )
+                    } finally {
+                        LongOpService.stop(toastContext)
+                    }
+                    val modelName = viewModel.modelFileName.value
+                    withContext(kotlinx.coroutines.Dispatchers.Main) {
+                        printerViewModel.sendUploadOnly(physical, modelName)
+                    }
+                }
+            },
+            onDismiss = { pendingMappingSend = null },
+        )
+    }
+    PendingMappingSend.Action.PrintAndUpload -> {
+        // existing FilamentMappingDialog(...) block, unchanged
+    }
+}
+```
+
+- [ ] **Step 2: Simplify the FilamentMappingDialog onConfirm to print-only**
+
+Inside the (now PrintAndUpload-only) `FilamentMappingDialog` `onConfirm`, replace the `when (pending.action) { … }` send dispatch with a direct print call, and set the mapping explicitly to the physical remap:
+
+```kotlin
+val sendMapping = com.u1.slicer.gcode.sendRemapForAction(
+    uploadOnly = false, physicalMapping = expanded,
+)
+val physical = try {
+    com.u1.slicer.gcode.applyPrintTimeRemap(
+        source = com.u1.slicer.gcode.CanonicalGcodePath.of(sourceFile),
+        output = com.u1.slicer.gcode.PhysicalGcodePath.of(remappedFile),
+        colorMapping = sendMapping,
+    )
+} finally {
+    LongOpService.stop(toastContext)
+}
+val modelName = viewModel.modelFileName.value
+withContext(kotlinx.coroutines.Dispatchers.Main) {
+    printerViewModel.sendAndPrint(physical, modelName)
+}
+```
+
+- [ ] **Step 3: Rename the button** (`MainActivity.kt` ~L2570)
+
+```kotlin
+Text(
+    "Upload Only",
+    fontWeight = FontWeight.Bold,
+    fontSize = 13.sp,
+    maxLines = 1,
+    softWrap = false,
+)
+```
+
+- [ ] **Step 4: Build**
+
+Run: `./gradlew assembleDebug --no-daemon`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/src/main/java/com/u1/slicer/MainActivity.kt
+git commit -m "feat: route Upload Only to confirmation sheet; rename button"
+```
+
+---
+
+### Task 3: Structural guard test
+
+**Files:**
+- Test: `app/src/test/java/com/u1/slicer/ui/UploadOnlyUxTest.kt` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+package com.u1.slicer.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Upload-Only UX (2026-06-03). Structural guard — the project has no Compose
+ * UI test harness. Asserts the send-to-hold path routes to the read-only
+ * UploadConfirmationDialog (not the slot picker) and the button is renamed.
+ */
+class UploadOnlyUxTest {
+
+    private fun source(rel: String): String {
+        val f = listOf(File(rel), File("../$rel")).firstOrNull { it.exists() }
+            ?: error("$rel not found from ${File(".").absolutePath}")
+        return f.readText()
+    }
+
+    @Test
+    fun uploadConfirmationDialog_exists() {
+        val src = source("app/src/main/java/com/u1/slicer/ui/FilamentMappingDialog.kt")
+        assertTrue(
+            "UploadConfirmationDialog composable must exist",
+            src.contains("fun UploadConfirmationDialog(")
+        )
+    }
+
+    @Test
+    fun uploadOnlyAction_routesToConfirmationDialog() {
+        val src = source("app/src/main/java/com/u1/slicer/MainActivity.kt")
+        assertTrue(
+            "Upload Only must render UploadConfirmationDialog",
+            src.contains("UploadConfirmationDialog(")
+        )
+    }
+
+    @Test
+    fun outlinedSendButton_renamedToUploadOnly() {
+        val src = source("app/src/main/java/com/u1/slicer/MainActivity.kt")
+        assertTrue("Button must read \"Upload Only\"", src.contains("\"Upload Only\""))
+        assertFalse(
+            "Stale \"Map & Upload\" label must be gone",
+            src.contains("\"Map & Upload\"")
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it passes** (code from Tasks 1-2 already in place)
+
+Run: `./gradlew testDebugUnitTest --tests "com.u1.slicer.ui.UploadOnlyUxTest" --no-daemon`
+Expected: PASS (3 tests).
+
+- [ ] **Step 3: Full unit suite**
+
+Run: `./gradlew testDebugUnitTest --no-daemon`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/src/test/java/com/u1/slicer/ui/UploadOnlyUxTest.kt
+git commit -m "test: structural guard for Upload Only routing + button rename"
+```
+
+---
+
+### Task 4: Build APK for on-device test
+
+- [ ] **Step 1: Build + stage APK**
+
+```bash
+./gradlew assembleDebug --no-daemon
+cp app/build/outputs/apk/debug/app-debug.apk "/g/My Drive/claude/u1-slicer-internal-memory-nozzle-fix-debug.apk"
+```
+
+Expected: APK ~41 MB at the G-drive path (overwrites the earlier prototype build).

--- a/docs/superpowers/specs/2026-06-03-upload-only-ux-design.md
+++ b/docs/superpowers/specs/2026-06-03-upload-only-ux-design.md
@@ -1,0 +1,96 @@
+# Upload-Only UX — design
+
+**Date:** 2026-06-03
+**Branch:** `fix/internal-memory-wrong-nozzle`
+**Related:** internal-memory wrong-nozzle root cause (this branch's first commit a0f5028); BACKLOG B102 (same family).
+
+## Problem
+
+The send-to-hold path ("Map & Upload") shows the full `FilamentMappingDialog`
+slot picker and collects a filament→physical-slot mapping. As of the Fix-A
+change on this branch, that mapping is **ignored** for held files: the upload
+now ships the **canonical** G-code body so the printer's own Filament Setup
+maps it once (avoiding the double-remap that put the first colour on the wrong
+nozzle). So the slot picker is now misleading — its choices do nothing for an
+upload.
+
+## Goal
+
+Make the Upload-Only path honest: no slot picker whose picks are silently
+discarded, and a clear hand-off that the **printer** does the mapping when the
+held print is started.
+
+## Non-goals
+
+- Changing the **Map & Print** path. It must keep baking the physical remap:
+  the Moonraker API start runs the body verbatim, so a canonical body would
+  print on the wrong nozzles. The two actions are intentionally different.
+- Unifying the two body representations into one uploaded file (that is the
+  heavier "Fix B" header-remap direction — out of scope here).
+
+## Design
+
+### 1. Button rename
+`MainActivity` Preview action buttons:
+- Filled primary **"Map & Print"** — unchanged (`onSendToPrinter` → `PrintAndUpload`).
+- Outlined **"Map & Upload"** → renamed **"Upload Only"** (`onUploadOnly` → `UploadOnly`).
+
+### 2. Branch the post-tap dialog on action
+Today both actions funnel into `FilamentMappingDialog` (the `CanonicalLookup.Present`
+branch around `MainActivity.kt:829`). Branch on the already-tracked
+`PendingMappingSend.action`:
+
+- **PrintAndUpload** → `FilamentMappingDialog`, exactly as today (slot picker,
+  auto-suggest, dup-slot handling, material-mismatch warnings, physical remap
+  baked at confirm).
+- **UploadOnly** → new lightweight **`UploadConfirmationDialog`**.
+
+### 3. `UploadConfirmationDialog` (new composable)
+Read-only confirmation, no slot picking. Contents:
+- Title: **"Upload to printer"**.
+- Model name + plate label (reuse what the mapping dialog shows).
+- A **read-only** list of the file's colours — one row per canonical filament:
+  **colour swatch + material name** only (no weights). Data source: the
+  `CanonicalFilamentList` already passed to the send path — **no G-code parsing**.
+  Plate-narrowed files use `plateFileIndices` for row labelling, same as the
+  mapping dialog, so labels match Prepare / Slice Summary.
+- One-line note: *"When you start this print on the printer, it will ask you
+  to assign each colour to a nozzle."*
+- Buttons: **Cancel** / **Upload**.
+- Single-colour files also use this sheet (one row). Uniform path.
+
+### 4. Confirm behavior
+On **Upload**: upload the **canonical body**. Reuses the committed Fix-A path —
+`applyPrintTimeRemap` with the mapping from `sendRemapForAction(uploadOnly = true, …)`
+(= empty list = verbatim copy) → `printerViewModel.sendUploadOnly(physical, modelName)`.
+Wrapped in `LongOpService` like the existing send (a verbatim copy of a large
+file still must survive backgrounding).
+
+Because no slot is chosen in-app, the B103/B128 material-mismatch warnings
+(which compare a *chosen slot's* material to the sliced material) do not apply
+to this path and are simply absent.
+
+### 5. Scope guard — legacy Absent path
+`CanonicalLookup.Absent` (legacy / unrecognised file, no canonical colour list)
+keeps its current direct upload for `UploadOnly` — it already does an
+identity/canonical copy, so it is correct; it just won't get the rich sheet
+(there are no canonical colours to show). Known, accepted minor inconsistency;
+not worth building a colour-less variant for rare legacy files.
+
+## Testing
+
+- **Logic (already covered):** `sendRemapForAction` contract + canonical-body-
+  preserved-for-Upload-Only vs remapped-for-Map-&-Print, in
+  `CanonicalExportMappingTest`.
+- **UI routing (new):** source-grep **structural guard** test (matching the
+  existing `ModelInfoDialogScrollTest` convention — the project has no Compose
+  UI harness) asserting: (a) `UploadConfirmationDialog` exists, (b) the
+  `UploadOnly` branch in `MainActivity` routes to it rather than
+  `FilamentMappingDialog`, (c) the outlined button text is "Upload Only".
+
+## Verification
+
+On-device with the reporter (Jon): load a multi-colour plate → **Upload Only** →
+confirm the new sheet → print from the printer's internal memory, assigning
+colours on the Filament Setup screen → first colour lands on the intended
+nozzle (the original bug: brown on nozzle 2, not 3).


### PR DESCRIPTION
## Problem
Reported on Discord (Jon): a multi-colour job sent via **Map & Upload** then started from the printer's **internal memory** printed the first colour on the wrong nozzle (brown on nozzle 3 instead of 2). **Map & Print** (direct) was correct. The held file and the direct-print file were **byte-identical**, so the cause was the print-*start*, not the file.

## Root cause — double tool-remap
The app bakes the physical filament→nozzle remap into the G-code **body** at Send time, leaving the descriptive **header** filament arrays in canonical (slicer) order. Direct **Map & Print** (Moonraker `print/start`) runs the body verbatim → correct. But the printer's own **Filament Setup** (used when starting a held file from internal memory) applies a canonical→physical map **on top of** the already-physical body → double remap → wrong nozzle. Same family as B102.

## Fix
1. **Upload-Only ships the canonical body** (`gcode.sendRemapForAction(uploadOnly=true)` → empty mapping → verbatim copy) so the printer maps it once via Filament Setup. **Map & Print is unchanged** (keeps the physical remap; runs verbatim).
2. **Honest UX:** the Upload-Only path no longer shows the slot picker (its picks were now ignored). New read-only `UploadConfirmationDialog` (model + colour/material list + "the printer will ask you to assign each colour to a nozzle"). Button **"Map & Upload" → "Upload Only"**.

## Tests
- `CanonicalExportMappingTest` (+4): `sendRemapForAction` contract; canonical body preserved for Upload-Only vs remapped for Map & Print.
- `UploadOnlyUxTest` (+3): structural guard — routing to `UploadConfirmationDialog`, composable exists, button relabelled.
- Full JVM unit suite green.

## Verification
On-device with reporter pending: Upload Only → print from internal memory → assign colours on Filament Setup → first colour on the intended nozzle.

Specs: `docs/superpowers/specs/2026-06-03-upload-only-ux-design.md`, plan `docs/superpowers/plans/2026-06-03-upload-only-ux.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)